### PR TITLE
kwil-admin docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode/
 
 npm-debug.log*
 yarn-debug.log*

--- a/docs/admin/index.mdx
+++ b/docs/admin/index.mdx
@@ -1,0 +1,22 @@
+---
+sidebar_position: 8
+sidebar_label: "Kwil Admin Tool"
+id: admin
+title: Kwil Node Administration Tool
+description: The Kwil admin tool
+slug: /admin
+---
+
+The Kwil node administration tool is a command line application called
+`kwil-admin`, which provides the following functionality to a node operator:
+
+1. Quick test network configuration.
+2. Node key generation.
+3. Interaction with a running `kwild` process via the node's authenticated gRPC interface.
+4. Validator operations.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/docs/admin/install.mdx
+++ b/docs/admin/install.mdx
@@ -11,37 +11,38 @@ Until the main Kwil DB repository is open source, the `kwil-admin` command line
 application may be (a) used from within the Kwil Docker image or (b) downloaded
 from the `kwil-cli` binary release repository.
 
-## From within the Kwil Docker image
+## From within the Kwil Docker Image
 
 To install the most recent Kwil image, run:
 
-```sh
+```bash
 docker pull kwildb/kwil:latest
 ```
 
 With a running container (e.g. `docker container run kwild:latest`), open an
 interactive shell in the container where you can run `kwil-admin` commands:
 
-```sh
+```bash
 docker exec -it <container-name-or-id> /bin/sh
 ```
 
-**DRAFT NOTE: this only works with the "shell" variant of the docker image, which is ~35MiB larger than the scratch one.  Maybe we make that standard?**
+## Download the Standalone `kwil-admin` Executable
 
-## Download the standalone `kwil-admin` executable
-
-Both the Kwil user CLI (`kwil-cli`) and the node administration tool will be
-packaged together for convenience. Download the [latest release](https://github.com/kwilteam/kwil-cli/releases)
+The Kwil daemon (`kwild`) and the node administration tool will be
+packaged together. Download the [latest release](https://github.com/kwilteam/kwil-binaries/releases)
 for your platform.  Extract the `kwil-admin` file from the archive and put it
 into a folder that is in your `PATH` environment.
 
-**DRAFT NOTE: we haven't actually bundled it with the kwil-cli downloads either**
+:::note
+The binaries will be packaged as described above after the next major release.
+The repository link may change soon.
+:::
 
 ## Verify Installation
 
 Open a terminal and run the following at the command prompt:
 
-```sh
+```bash
 kwil-admin version
 ```
 

--- a/docs/admin/install.mdx
+++ b/docs/admin/install.mdx
@@ -1,0 +1,50 @@
+---
+sidebar_position: 1
+sidebar_label: "Installation"
+id: admin-installation
+title: Installation
+description: How to install the Kwil admin tool
+slug: /admin/installation
+---
+
+Until the main Kwil DB repository is open source, the `kwil-admin` command line
+application may be (a) used from within the Kwil Docker image or (b) downloaded
+from the `kwil-cli` binary release repository.
+
+## From within the Kwil Docker image
+
+To install the most recent Kwil image, run:
+
+```sh
+docker pull kwildb/kwil:latest
+```
+
+With a running container (e.g. `docker container run kwild:latest`), open an
+interactive shell in the container where you can run `kwil-admin` commands:
+
+```sh
+docker exec -it <container-name-or-id> /bin/sh
+```
+
+**DRAFT NOTE: this only works with the "shell" variant of the docker image, which is ~35MiB larger than the scratch one.  Maybe we make that standard?**
+
+## Download the standalone `kwil-admin` executable
+
+Both the Kwil user CLI (`kwil-cli`) and the node administration tool will be
+packaged together for convenience. Download the [latest release](https://github.com/kwilteam/kwil-cli/releases)
+for your platform.  Extract the `kwil-admin` file from the archive and put it
+into a folder that is in your `PATH` environment.
+
+**DRAFT NOTE: we haven't actually bundled it with the kwil-cli downloads either**
+
+## Verify Installation
+
+Open a terminal and run the following at the command prompt:
+
+```sh
+kwil-admin version
+```
+
+If installed correctly, it should display a message such as `kwil-admin version 0.5.1`.
+
+Continue to the [Usage page](./usage) for a description of all the available commands.

--- a/docs/admin/keys.mdx
+++ b/docs/admin/keys.mdx
@@ -1,0 +1,55 @@
+---
+sidebar_position: 3
+sidebar_label: "Key Management"
+id: admin-keys
+title: Key Generation and Information
+description: Key generation and inspection with the key subcommand
+slug: /admin/keys
+---
+
+The `key` command provides subcommands for private key generation
+and inspection. These are the private keys that identify the node on the network
+and provide validator transaction signing capability.
+
+## Generation
+
+To generate a node private key, the basic syntax is:
+
+```sh
+kwil-admin key gen [--key-file KEY-FILE]
+```
+
+The square brackets around the `--key-file` flag indicate that it is optional.
+If you specify a file name, the generated key will be written to that file,
+otherwise it will be printed to stdout with additional information. The written
+file is suitable for use as `kwild` private key file.
+
+## Key Information
+
+To display information on a private key:
+
+```sh
+kwil-admin key info [--key-file KEY-FILE] [PRIVKEY]
+```
+
+This will read the key from a file or as a positional argument (hexadecimal
+string). If providing the key on the command line, be aware of the security
+implications, and prefer the `--key-file` argument when possible.
+
+For example, using a test key generated with the `kwil-admin key gen --key-file=./testkey` command:
+
+```sh
+$ kwil-admin key info --key-file ./testkey
+Private key (hex): 95c36c2b8abcac958d1c52ea0081c1de13eafaf8d8aa314c20ea69e1aa84f0096ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0
+Private key (base64): lcNsK4q8rJWNHFLqAIHB3hPq+vjYqjFMIOpp4aqE8AluysqOk5TJOahYwse0essdsmqW16s4vXAvo4IMUDTp0A==
+Public key (base64): bsrKjpOUyTmoWMLHtHrLHbJqlterOL1wL6OCDFA06dA=
+Public key (cometized hex): PubKeyEd25519{6ECACA8E9394C939A858C2C7B47ACB1DB26A96D7AB38BD702FA3820C5034E9D0}
+Public key (plain hex): 6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0
+Address (string): FDF22EFD7EDAED3F1E6058A2116604DBB19EABE4
+Node ID: fdf22efd7edaed3f1e6058a2116604dbb19eabe4
+```
+
+The derived address and public key may be required to configure a new genesis
+configuration for a private network with this nodes as an initial validator. The
+various public key formats and the node ID are also helpful when interpreting
+node logs.

--- a/docs/admin/keys.mdx
+++ b/docs/admin/keys.mdx
@@ -15,7 +15,7 @@ and provide validator transaction signing capability.
 
 To generate a node private key, the basic syntax is:
 
-```sh
+```
 kwil-admin key gen [--key-file KEY-FILE]
 ```
 
@@ -28,7 +28,7 @@ file is suitable for use as `kwild` private key file.
 
 To display information on a private key:
 
-```sh
+```
 kwil-admin key info [--key-file KEY-FILE] [PRIVKEY]
 ```
 
@@ -38,7 +38,7 @@ implications, and prefer the `--key-file` argument when possible.
 
 For example, using a test key generated with the `kwil-admin key gen --key-file=./testkey` command:
 
-```sh
+```
 $ kwil-admin key info --key-file ./testkey
 Private key (hex): 95c36c2b8abcac958d1c52ea0081c1de13eafaf8d8aa314c20ea69e1aa84f0096ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0
 Private key (base64): lcNsK4q8rJWNHFLqAIHB3hPq+vjYqjFMIOpp4aqE8AluysqOk5TJOahYwse0essdsmqW16s4vXAvo4IMUDTp0A==

--- a/docs/admin/node.mdx
+++ b/docs/admin/node.mdx
@@ -1,0 +1,192 @@
+---
+sidebar_position: 6
+sidebar_label: "Node RPC"
+id: admin-node
+title: Administration of a Running Node
+description: Controlling a running node on the authenticated RPC service with the validator command
+slug: /admin/node
+---
+
+The `node` command is used to control a running Kwil node via its authenticated
+RPC service.
+
+The subcommands share the following syntax:
+
+```
+kwil-admin node [--rpcserver RPCSERVER] [--authrpc-cert AUTHRPC-CERT]
+  [--tlskey TLSKEY] [--tlscert TLSCERT] <command> [<args>]
+```
+
+## Setup
+
+:::warning
+The assumption is that the user of `kwil-admin` is the node
+operator. Access must not be granted to untrusted parties.
+:::
+
+Communication between `kwil-admin` and `kwild` is both encrypted and
+mutually-authenticated. Each side has their own key pair, where the node's is
+used to encrypt the communications, and the client's is used to authenticate
+itself with the node. Thus, setup involves generating client credentials, and
+setting them as an authorized RPC client on the Node.
+
+Use of the `node` commands requires the following:
+
+- The node's TLS (encrypted transport) certificate, specified with
+  `--authrpc-cert`. The default is "kwild.cert". This would be retrieved from
+  the node where it is located at `~/.kwild/rpc.cert` by default.
+- RPC client credentials. This is a key pair used to authenticate `kwil-admin`
+  (the client) with `kwild` (the server).  The key and certificate parts are
+  specified by `--tlskey` and `--tlscert`.
+- Adding the client certificate to the Node's allowed clients, which is locate
+  on the node machine as `~/.kwild/clients.pem` by default.
+- Configure the Kwil node's `admin_listen_addr` so the service is accessible to
+  `kwil-admin`. See [Kwil Node Configuration](../daemon/config) for more
+  information.
+
+The `kwild` process may be running locally, on a remote host, or inside a Docker
+container. Set and expose the admin RPC service ports as required.
+
+:::note
+Rapidly evolving procedures here. This is all likely to change soon.
+:::
+
+### Generation of Credentials on the Node
+
+The node will generate its own TLS key and certificate, which is used encrypt
+the communications on its authenticated RPC server. As a convenience, `kwild`
+will also generate new *client* credentials on start up if the file
+`~/.kwild/clients.pem` does not exist.
+
+The corresponding `auth.{cert,key}` files may then be used by the operator to
+with th `kwil-admin node` commands for remote access to the node. 
+
+## Generation of Credentials by `kwil-admin`
+
+The `kwil-admin node gen-auth-key` command may be used to generate new
+credentials to `~/.kwil-admin/auth.{cert,key}`.
+
+With this method, the contents of the `auth.cert` file must be appended to the
+node's `clients.pem` file. Specifically,
+
+1. Generate credentials with `./kwil-admin node gen-auth-key`
+2. Securely copy the `~/.kwil-admin/auth.cert` file to the machine where `kwild`
+   is running, if it is not the same host.
+3. Append the contents of the copied `auth.cert` to the node's `clients.pem` file.
+
+  ```sh
+  cat auth.cert >> ~/.kwild/clients.pem
+  ```
+
+If `kwil-admin` is being used on the same machine as `kwild`, you would skip
+copy step and do:
+
+```sh
+cat ~/.kwil-admin/auth.cert >> ~/.kwild/clients.pem
+```
+
+## Commands
+
+The following commands perform node actions via the node's authenticated RPC
+service, configured as described above. All flags are optional if the required
+files are placed in the `~/.kwil-admin` folder.
+
+```
+Usage: kwil-admin node [--rpcserver RPCSERVER] [--authrpc-cert AUTHRPC-CERT]
+  [--tlskey TLSKEY] [--tlscert TLSCERT] <command> [<args>]
+
+Options:
+  --rpcserver RPCSERVER, -s RPCSERVER
+                         admin RPC server address [default: 127.0.0.1:50151]
+  --authrpc-cert AUTHRPC-CERT
+                         kwild's TLS certificate [default: kwild.cert]
+  --tlskey TLSKEY        our TLS key file to establish a mTLS (authenticated)
+                         connection [default: auth.key]
+  --tlscert TLSCERT      our TLS certificate file for server to authenticate us
+                         [default: auth.cert]
+  --help, -h             display this help and exit
+  --version              display version and exit
+```
+
+### Version
+
+The `version` subcommand returns `kwild`'s version string set at compile time.
+For example, a development version of `kwild` may report something similar to
+the following:
+
+```sh
+$ kwil-admin node version
+kwild version 0.5.1-pre+0975d68fb.dirty
+```
+
+### Status
+
+Node status is requested with the `status` subcommand:
+
+For example, `kwil-admin node status` returns JSON formatted status information:
+
+```json
+{
+  "node": {
+    "chain_id": "kwil-chain-nUkVIp",
+    "name": "kwilnode42",
+    "node_id": "9fde182db6dc5c2d5a08f395cdc9320a76a4f15d",
+    "proto_ver": 8,
+    "app_ver": 0,
+    "block_ver": 0,
+    "listen_addr": "tcp://0.0.0.0:26656",
+    "rpc_addr": "tcp://0.0.0.0:26657"
+  },
+  "sync": {
+    "app_hash": "51ffe4001668c0ea7791a2e8d647fe88d7542f2594e91382ca0a7026db6a1571",
+    "best_block_hash": "9f7d2fc800e3926e04db7ae72778faa47cb551394662dcc131824203efa9bbd8",
+    "best_block_height": 27462,
+    "best_block_time": "2023-09-19T15:46:36.693-05:00",
+    "syncing": false
+  },
+  "current_validator": {
+    "pubkey": "d659e53ff403c52a1ae85445c51dd714d57e75b4ae6fa2e009a9082bfef870db",
+    "pubkey_type": "ed25519",
+    "power": 1
+  }
+}
+```
+
+### Peers
+
+A list of the peers currently connected to the node are reported with the
+`peers` subcommand. For example, the output of running `kwil-admin node peers`
+on a node with 2 connected peers would look like:
+
+```json
+[
+  {
+    "node": {
+      "chain_id": "chain-Ba2NYd",
+      "name": "k2",
+      "node_id": "658ea486c3fecf0e6869ad5fc632dd17fc35691a",
+      "proto_ver": 8,
+      "app_ver": 0,
+      "block_ver": 0,
+      "listen_addr": "tcp://127.0.0.1:26756",
+      "rpc_addr": "tcp://127.0.0.1:26757"
+    },
+    "inbound": false,
+    "remote_addr": "127.0.0.1"
+  },
+  {
+    "node": {
+      "chain_id": "chain-Ba2NYd",
+      "name": "k3",
+      "node_id": "8224ce41147ef2f791a06b1bf5e3fa77d0d543f6",
+      "proto_ver": 8,
+      "app_ver": 0,
+      "block_ver": 0,
+      "listen_addr": "tcp://127.0.0.1:26856",
+      "rpc_addr": "tcp://127.0.0.1:26857"
+    },
+    "inbound": false,
+    "remote_addr": "127.0.0.1"
+  }
+]
+```

--- a/docs/admin/node.mdx
+++ b/docs/admin/node.mdx
@@ -28,7 +28,7 @@ Communication between `kwil-admin` and `kwild` is both encrypted and
 mutually-authenticated. Each side has their own key pair, where the node's is
 used to encrypt the communications, and the client's is used to authenticate
 itself with the node. Thus, setup involves generating client credentials, and
-setting them as an authorized RPC client on the Node.
+setting them as an authorized RPC client on the node.
 
 Use of the `node` commands requires the following:
 
@@ -38,7 +38,7 @@ Use of the `node` commands requires the following:
 - RPC client credentials. This is a key pair used to authenticate `kwil-admin`
   (the client) with `kwild` (the server).  The key and certificate parts are
   specified by `--tlskey` and `--tlscert`.
-- Adding the client certificate to the Node's allowed clients, which is locate
+- Adding the client certificate to the node's allowed clients, which is locate
   on the node machine as `~/.kwild/clients.pem` by default.
 - Configure the Kwil node's `admin_listen_addr` so the service is accessible to
   `kwil-admin`. See [Kwil Node Configuration](../daemon/config) for more
@@ -51,15 +51,21 @@ container. Set and expose the admin RPC service ports as required.
 Rapidly evolving procedures here. This is all likely to change soon.
 :::
 
+Described below are two ways to generate and set client credentials.
+
 ### Generation of Credentials on the Node
 
 The node will generate its own TLS key and certificate, which is used encrypt
-the communications on its authenticated RPC server. As a convenience, `kwild`
-will also generate new *client* credentials on start up if the file
-`~/.kwild/clients.pem` does not exist.
+the communications on its authenticated RPC server. If the `--autogen` flag is
+provided, the node will also generate new *client* credentials on start up if
+the file `~/.kwild/clients.pem` does not exist. The corresponding
+`auth.{cert,key}` files may then be used by the operator with `kwil-admin node`
+commands for remote access to the node.
 
-The corresponding `auth.{cert,key}` files may then be used by the operator to
-with th `kwil-admin node` commands for remote access to the node. 
+:::note
+This approach is intended for "quickstart" workflows. The following method using
+`kwil-admin` for generation is preferred.
+:::
 
 ## Generation of Credentials by `kwil-admin`
 
@@ -74,14 +80,14 @@ node's `clients.pem` file. Specifically,
    is running, if it is not the same host.
 3. Append the contents of the copied `auth.cert` to the node's `clients.pem` file.
 
-  ```sh
+  ```bash
   cat auth.cert >> ~/.kwild/clients.pem
   ```
 
-If `kwil-admin` is being used on the same machine as `kwild`, you would skip
+If `kwil-admin` is being used on the same machine as `kwild`, you would skip the
 copy step and do:
 
-```sh
+```bash
 cat ~/.kwil-admin/auth.cert >> ~/.kwild/clients.pem
 ```
 
@@ -114,7 +120,7 @@ The `version` subcommand returns `kwild`'s version string set at compile time.
 For example, a development version of `kwild` may report something similar to
 the following:
 
-```sh
+```
 $ kwil-admin node version
 kwild version 0.5.1-pre+0975d68fb.dirty
 ```

--- a/docs/admin/setup.mdx
+++ b/docs/admin/setup.mdx
@@ -1,0 +1,137 @@
+---
+sidebar_position: 4
+sidebar_label: "Node Setup"
+id: admin-setup
+title: Node Setup and Configuration Tools
+description: Node setup and configuration with the setup subcommand
+slug: /admin/setup
+---
+
+The `setup` command provides functions for creating and managing node
+configuration and data, including:
+
+* performing quick setup of a standalone Kwil node (`init`) and Kwil test networks (`testnet`)
+* updating genesis config with initial SQLite files (`genesis-hash`)
+* resetting node state (`reset-state`) and all node data files (`reset`)
+
+## Quick Setup of a Single Kwil Node
+
+The `init` command facilitates quick setup of an isolated Kwil node on a fresh
+network in which that node is the single validator.  This permits rapid
+prototyping and evaluation of Kwil DB functionality.
+
+For example, to create a node configuration for a new network in a root Kwild
+Daemon folder at `~/.kwild-new`:
+
+```sh
+$ kwil-admin setup init -o ~/.kwild-new
+Generated genesis file /home/user/.kwild-new/abci/config/genesis.json
+Successfully initialized node directory:  /home/user/.kwild-new
+```
+
+The above command also generated a new `config.toml` and `private_key` file in
+the node directory.
+
+Additional nodes may join this new network by specifying the existing node as a
+persistent peer in `kwild`'s configuration and in the validators section of the
+genesis configuration. See [Kwil Daemon Configuration](../daemon/config) for
+more information on node setup.
+
+## Creating a New Test Network of Several Nodes
+
+The `setup testnet` command is used to create multiple node configurations, all
+with the same genesis config, and pre-configured to connect to each other. This
+command has several options:
+
+```
+kwil-admin setup testnet [--validators V] [--non-validators N] [--config FILE]
+  [--output-dir DIR] [--node-dir-prefix PRE] [--hostname-prefix PRE]
+  [--hostname-suffix SUF] [--starting-ip IP] [--hostname HOSTNAME] [--p2p-port PORT]
+```
+
+There are defaults for each flag, with the output writing to a folder called
+`.testnet` in the current folder.  For example, the following command creates a
+new testnet work with 8 total nodes comprising 4 validators and 4 non-validators:
+
+```sh
+$ ./kwil-admin setup testnet -o ~/.kwild-testnet-xyz
+Successfully initialized 8 node directories: /home/jon/.kwild-testnet-xyz
+
+$ tree ~/.kwild-testnet-xyz
+/home/user/.kwild-testnet-xyz
+├── node0
+│   ├── abci
+│   │   ├── config
+│   │   │   └── genesis.json
+│   │   └── data
+│   ├── config.toml
+│   └── private_key
+├── node1
+│   ├── abci
+│   │   ├── config
+│   │   │   └── genesis.json
+...
+```
+
+The config files for each of the nodes will specify all of the other nodes a
+persistent peers so that they will connect to each other on startup. This is
+generally only practical for small test networks with fewer than 12 nodes.
+
+The following options may be used to control what is generated:
+
+- `--validators` or `-v` is number of validators [default: 4]
+- `--non-validators` or `-n` is the number of non-validators [default: 4]
+- `--config` is a template config file to use, default is none
+- `--output-dir` or `-o` is the parent directory for all of generated node folders [default: ".testnet"]
+- `--node-dir-prefix` is the prefix for the node directories (node results in node0, node1, ...) [default: "node"]
+- `--hostname-prefix` is the prefix for node host names e.g. node results in node0, node1, etc.
+- `--hostname-suffix` is the suffix for node host names e.g. .example.com results in node0.example.com, node1.example.com, etc.
+- `--starting-ip` is the starting IP address of the first network node, with subsequent nodes on the next address in the subnet
+- `--hostname` overrides all hostnames of the nodes
+- `--p2p-port` or `-p` is the TCP port port on which the nodes listens for P2P connections
+
+## Updating Genesis Config with Initial SQLite Data
+
+If preparing a network with initial databases, it is required to update the "app
+hash" in `kwild`'s genesis configuration to reflect the initial state that
+includes one or more SQLite files. The syntax is:
+
+```
+kwil-admin setup genesis-hash [--genesis GENESIS] [DBDIR]
+```
+
+Both inputs are optional, using default paths. `GENESIS` is the path to the
+genesis file to patch, which is `~/.kwild/abci/config/genesis.json` by default.
+The `DBDIR` argument is the directory containing all of kwild's .sqlite files to
+be hashed, which is `~/.kwild/data/kwil.db/` by default.
+
+## Resetting All Application Data
+
+To delete all of a Kwil node's data files, use the `reset` command.
+
+**WARNING: This command should not be used on production systems. This should
+only be used to reset disposable test nodes.**
+
+```
+kwil-admin setup reset [--root_dir DIR] [--force] [--sqlpath DIR] [--snappath DIR]
+```
+
+This command only requires one: (a) `--root_dir` to specify a node root
+directory containing the files to reset, or (b) `--force` to automatically reset
+the files in the default node root directory at `~/.kwild`.
+
+The paths to the SQLite files (`--sqlpath`) and snapshots (`--snappath`) are
+optional, but provided here since they are configurable on the node.
+
+## Resetting Only Chain state
+
+To reset the block chain state data while leaving all of the other application
+data such as the SQLite databases intact, use the `reset-state` command. This
+will delete the data files under `<root_dir>/abci/data`
+
+```
+kwil-admin setup reset-state [--root_dir DIR] [--force]
+```
+
+As with the `reset` command, only one of the two flags are required.
+

--- a/docs/admin/setup.mdx
+++ b/docs/admin/setup.mdx
@@ -12,7 +12,7 @@ configuration and data, including:
 
 * performing quick setup of a standalone Kwil node (`init`) and Kwil test networks (`testnet`)
 * updating genesis config with initial SQLite files (`genesis-hash`)
-* resetting node state (`reset-state`) and all node data files (`reset`)
+* resetting node state and all data files (`reset`)
 
 ## Quick Setup of a Single Kwil Node
 
@@ -20,10 +20,10 @@ The `init` command facilitates quick setup of an isolated Kwil node on a fresh
 network in which that node is the single validator.  This permits rapid
 prototyping and evaluation of Kwil DB functionality.
 
-For example, to create a node configuration for a new network in a root Kwild
-Daemon folder at `~/.kwild-new`:
+For example, to create a node configuration for a new network in a node root
+folder at `~/.kwild-new`:
 
-```sh
+```
 $ kwil-admin setup init -o ~/.kwild-new
 Generated genesis file /home/user/.kwild-new/abci/config/genesis.json
 Successfully initialized node directory:  /home/user/.kwild-new
@@ -51,9 +51,9 @@ kwil-admin setup testnet [--validators V] [--non-validators N] [--config FILE]
 
 There are defaults for each flag, with the output writing to a folder called
 `.testnet` in the current folder.  For example, the following command creates a
-new testnet work with 8 total nodes comprising 4 validators and 4 non-validators:
+new test network with 8 total nodes comprising 4 validators and 4 non-validators:
 
-```sh
+```
 $ ./kwil-admin setup testnet -o ~/.kwild-testnet-xyz
 Successfully initialized 8 node directories: /home/jon/.kwild-testnet-xyz
 
@@ -73,13 +73,13 @@ $ tree ~/.kwild-testnet-xyz
 ...
 ```
 
-The config files for each of the nodes will specify all of the other nodes a
+The config files for each of the nodes will specify all of the other nodes as
 persistent peers so that they will connect to each other on startup. This is
 generally only practical for small test networks with fewer than 12 nodes.
 
 The following options may be used to control what is generated:
 
-- `--validators` or `-v` is number of validators [default: 4]
+- `--validators` or `-v` is the number of validators [default: 4]
 - `--non-validators` or `-n` is the number of non-validators [default: 4]
 - `--config` is a template config file to use, default is none
 - `--output-dir` or `-o` is the parent directory for all of generated node folders [default: ".testnet"]
@@ -88,7 +88,7 @@ The following options may be used to control what is generated:
 - `--hostname-suffix` is the suffix for node host names e.g. .example.com results in node0.example.com, node1.example.com, etc.
 - `--starting-ip` is the starting IP address of the first network node, with subsequent nodes on the next address in the subnet
 - `--hostname` overrides all hostnames of the nodes
-- `--p2p-port` or `-p` is the TCP port port on which the nodes listens for P2P connections
+- `--p2p-port` or `-p` is the TCP port on which each node listens for P2P connections
 
 ## Updating Genesis Config with Initial SQLite Data
 
@@ -102,8 +102,8 @@ kwil-admin setup genesis-hash [--genesis GENESIS] [DBDIR]
 
 Both inputs are optional, using default paths. `GENESIS` is the path to the
 genesis file to patch, which is `~/.kwild/abci/config/genesis.json` by default.
-The `DBDIR` argument is the directory containing all of kwild's .sqlite files to
-be hashed, which is `~/.kwild/data/kwil.db/` by default.
+The `DBDIR` argument is the directory containing all of `kwild`'s SQLite files
+to be hashed, which is `~/.kwild/data/kwil.db/` by default.
 
 ## Resetting All Application Data
 
@@ -122,16 +122,3 @@ the files in the default node root directory at `~/.kwild`.
 
 The paths to the SQLite files (`--sqlpath`) and snapshots (`--snappath`) are
 optional, but provided here since they are configurable on the node.
-
-## Resetting Only Chain state
-
-To reset the block chain state data while leaving all of the other application
-data such as the SQLite databases intact, use the `reset-state` command. This
-will delete the data files under `<root_dir>/abci/data`
-
-```
-kwil-admin setup reset-state [--root_dir DIR] [--force]
-```
-
-As with the `reset` command, only one of the two flags are required.
-

--- a/docs/admin/usage.mdx
+++ b/docs/admin/usage.mdx
@@ -13,7 +13,7 @@ are accessible through sub-commands.
 To show `kwil-admin` usage and all of the available top level commands, provide
 the `-h` or `--help` flag:
 
-```sh
+```
 $ kwil-admin -h
 kwil-admin: The Kwil node admin tool
 
@@ -36,7 +36,7 @@ Commands:
 With the exception of `help` and `version`, each of the commands must be used
 with a sub-command. For example, to list the `key` sub-commands:
 
-```sh
+```
 $ ./kwil-admin key -h
 kwil-admin: The Kwil node admin tool
 
@@ -52,7 +52,7 @@ Commands:
 
 To see usage of the `key info` sub command:
 
-```sh
+```
 $ ./kwil-admin key info -h
 kwil-admin: The Kwil node admin tool
 

--- a/docs/admin/usage.mdx
+++ b/docs/admin/usage.mdx
@@ -1,0 +1,74 @@
+---
+sidebar_position: 2
+sidebar_label: "Usage"
+id: admin-use
+title: Using the Kwil admin tool
+description: How to use the Kwil admin tool
+slug: /admin/usage
+---
+
+`kwil-admin` provides several functions for node setup and administration that
+are accessible through sub-commands.
+
+To show `kwil-admin` usage and all of the available top level commands, provide
+the `-h` or `--help` flag:
+
+```sh
+$ kwil-admin -h
+kwil-admin: The Kwil node admin tool
+
+kwil-admin version 0.5.1
+Usage: kwil-admin <command> [<args>]
+
+Options:
+  --help, -h             display this help and exit
+  --version              display version and exit
+
+Commands:
+  key
+  setup
+  validators
+  node
+  help
+  version
+```
+
+With the exception of `help` and `version`, each of the commands must be used
+with a sub-command. For example, to list the `key` sub-commands:
+
+```sh
+$ ./kwil-admin key -h
+kwil-admin: The Kwil node admin tool
+
+kwil-admin version 0.5.1
+Usage: kwil-admin key <command> [<args>]
+  --help, -h             display this help and exit
+  --version              display version and exit
+
+Commands:
+  info                   Display info about a node private key.
+  gen                    Generate a node private key.
+```
+
+To see usage of the `key info` sub command:
+
+```sh
+$ ./kwil-admin key info -h
+kwil-admin: The Kwil node admin tool
+
+kwil-admin version 0.5.1
+Usage: kwil-admin key info [--key-file KEY-FILE] [PRIVKEY]
+
+Positional arguments:
+  PRIVKEY                Private key (hexadecimal string)
+
+Options:
+  --key-file KEY-FILE, -k KEY-FILE
+                         file containing the private key
+  --help, -h             display this help and exit
+  --version              display version and exit
+```
+
+The following sections will describe each of the commands provided by
+`kwil-admin`, but always reference the syntax and full set of options shown by
+appending the `-h` (or `--help`) flag to the full command in question.

--- a/docs/admin/validators.mdx
+++ b/docs/admin/validators.mdx
@@ -1,0 +1,95 @@
+---
+sidebar_position: 5
+sidebar_label: "Validator Commands"
+id: admin-validators
+title: Validator Information and Transactions
+description: Validator transactions (join/approve/leave) and queries with the validator command
+slug: /admin/validators
+---
+
+The `validators` command provides functions for creating and broadcasting
+validator-related transactions (join/approve/leave), and retrieving information
+on the current validators and join requests.
+
+```
+kwil-admin validators [--rpcserver RPCSERVER] <command> [<args>]
+```
+
+Each of the subcommands uses a Kwil node's public RPC service (`--rpcserver`),
+where the default is "127.0.0.1:50051".
+
+## List Current Validators
+
+The current validator set is retrieved with the `list` command.  For example:
+
+```
+$ kwild validator list
+Current validator set:
+  0. {pubkey = 9fed4b19eab0cf87370bff0c7ef04cfcff5b268d096578d3ef5ae3c1010939d8, power = 1}
+  1. {pubkey = f1693096d252eac5e366436314996ec39c189dffb997ad7414ed306e3d9244c4, power = 1}
+  2. {pubkey = f28e3cd6d11e9c5d2d00ea8b9c1e18cc01e568f0b186888fb274567461774fbc, power = 1}
+```
+
+## Show Join Request Status
+
+To view the status of an active join request, use the `join-status` command:
+
+```
+kwil-admin validators join-status JOINER
+```
+
+This command requires only the public key of the candidate validator `JOINER`
+with an active join request. For example,
+
+```
+$ kwild validator join-status "6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0"
+Candidate: 6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0 (want power 1)
+ Validator 9fed4b19eab0cf87370bff0c7ef04cfcff5b268d096578d3ef5ae3c1010939d8, approved = false
+ Validator f1693096d252eac5e366436314996ec39c189dffb997ad7414ed306e3d9244c4, approved = false
+ Validator f28e3cd6d11e9c5d2d00ea8b9c1e18cc01e568f0b186888fb274567461774fbc, approved = false
+```
+
+## Join
+
+A node may request to join as a validator with the `join` subcommand:
+
+```
+kwil-admin validators join [--key-file KEY-FILE] [PRIVKEY]
+```
+
+The private key of the node (prospective validator) that will sign the
+transaction is specified with either a file containing the key, or a positional
+argument containing the hexadecimal string for the key.  For example:
+
+```sh
+$ ./kwild validator join --key-file ~/secrets/validator_private_key
+Joining the network as a validator...
+Node PublicKey: d692a88b6fee8d1399f7aab70db25001080dbf2fe8ca4f345e0fdca6b853713a
+tx hash: 125ae9009a5056a152542aa84e97a2a49c547e492dffdfea50eb44623fbb3efb
+tx sender: 1pKoi2/ujROZ96q3DbJQAQgNvy/oyk80Xg/cprhTcTo=
+tx signature (ed25519): ce56440b1ecd529b5345a6662f3a30831b7d85ddc714036c4e7b124dd0481429478c1459c1833a8e9fa338329b0f217ca04c4381bb53679e3d72dec3317e7b09
+tx payload (validator_join): 0001e2a0d692a88b6fee8d1399f7aab70db25001080dbf2fe8ca4f345e0fdca6b853713a01
+```
+
+## Approve
+
+A current validator may approve an active join request for a candidate
+validator using the `approve` subcommand:
+
+```
+kwil-admin validators approve [--key-file KEY-FILE] JOINER [PRIVKEY]
+```
+
+This command has the same syntax as the `join` command except with the addition
+of the `JOINER` positional argument, which specifies the public key
+(hexadecimal) of the candidate validator that is being approved.
+
+## Leave
+
+A current validator may leave the validator set using the `leave` command:
+
+```
+kwil-admin validators leave [--key-file KEY-FILE] [PRIVKEY]
+```
+
+The syntax is identical to the `join` command.

--- a/docs/admin/validators.mdx
+++ b/docs/admin/validators.mdx
@@ -42,7 +42,7 @@ This command requires only the public key of the candidate validator `JOINER`
 with an active join request. For example,
 
 ```
-$ kwild validator join-status "6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0"
+$ kwil-admin validators join-status "6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0"
 Candidate: 6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0 (want power 1)
  Validator 9fed4b19eab0cf87370bff0c7ef04cfcff5b268d096578d3ef5ae3c1010939d8, approved = false
  Validator f1693096d252eac5e366436314996ec39c189dffb997ad7414ed306e3d9244c4, approved = false
@@ -61,8 +61,8 @@ The private key of the node (prospective validator) that will sign the
 transaction is specified with either a file containing the key, or a positional
 argument containing the hexadecimal string for the key.  For example:
 
-```sh
-$ ./kwild validator join --key-file ~/secrets/validator_private_key
+```
+$ kwil-admin validators join --key-file ~/secrets/validator_private_key
 Joining the network as a validator...
 Node PublicKey: d692a88b6fee8d1399f7aab70db25001080dbf2fe8ca4f345e0fdca6b853713a
 tx hash: 125ae9009a5056a152542aa84e97a2a49c547e492dffdfea50eb44623fbb3efb

--- a/docs/cli/databases.md
+++ b/docs/cli/databases.md
@@ -23,7 +23,7 @@ The database subcommand contains all of the commands necessary for interacting w
 
 The `deploy` subcommand is used to deploy a database schema. The `deploy` command takes no arguments, however has one required flag.  Users must specify the relative filepath to their JSON with the `--path` or `-p` flag.
 
-```sh
+```bash
 kwil-cli database deploy --path=./my_db.json
 ```
 
@@ -33,7 +33,7 @@ kwil-cli database deploy --path=./my_db.json
 
 The drop subcommand is used to drop a deployed database.  You can only drop databases that have been deployed with your configured wallet.  The drop command takes one argument, which is the name of the database you wish to drop.
 
-```sh
+```bash
 kwil-cli database drop mydb
 ```
 
@@ -42,7 +42,7 @@ kwil-cli database drop mydb
 The read subcommand is used to execute an ad-hoc SELECT statement against a database.
 This statement cannot modify state, and is therefore read-only.  It takes one argument, which is the SQL query you wish to execute.  It can be configured to point to either database ID's or databases identified by name and owner:
 
-```sh
+```bash
 kwil-cli database query 'SELECT * FROM my_table LIMIT 10' --dbid xca123
 
 kwil-cli database query 'SELECT * FROM my_table LIMIT 10' --name my_db --owner 0xabc123
@@ -52,7 +52,7 @@ kwil-cli database query 'SELECT * FROM my_table LIMIT 10' --name my_db --owner 0
 
 The list subcommand is used to list the databases deployed by a particular wallet.  This command takes no arguments, and by default will list the databases for the wallet you have configured.  You can list databases deployed from any wallet using the optional --owner (or -o) flag.
 
-```sh
+```bash
 kwil-cli database list --owner=0x37Fc1953e4A26007E6Df52f06B5897a998F51f5D
 ```
 
@@ -62,19 +62,19 @@ The read-schema subcommand is used to display schema information for a deployed 
 
 To select a database by its owner and name, you can use the `--owner`(or `-o`) flag, and the `--name` (or `-n`) flag.  If no `--owner` flag is provided, it will default to databases owned by the wallet you are using, if a wallet has been [configured](../cli/configuration).
 
-```sh
+```bash
 kwil-cli database read-schema --name=mydb
 ```
 
 or
 
-```sh
+```bash
 kwil-cli database read-schema --owner=0x37Fc1953e4A26007E6Df52f06B5897a998F51f5D --name=db1
 ```
 
 Alternatively, you can pass the `--dbid` flag (or `-i`)`  to identify the database to read from.
 
-```sh
+```bash
 kwil-cli database read-schema --dbid=xc57b99f921ac99896d861b4462d7874212e0a63e53b2c53d91b0f6d2
 ```
 
@@ -88,13 +88,13 @@ To specify the name of the query you wish to execute, you also have to pass a re
 
 Finally, in order to pass parameters to the query, you must specify the inputs as arguments.  You must first specify the name of the parameter you are filling, and then the value.  Queries should follow the layout below:
 
-```sh
+```bash
 kwil-cli database execute <input_name_1>:<value> <input_name_2>:<value> --action=<action_name> --dbid=<db_id>
 ```
 
 For example, if you were executing an INSERT query named "create_user" that took two parameters: name (text), and age (int), you would pass my arguments as follows:
 
-```sh
+```bash
 kwil-cli database execute name:satoshi age:32 --action=create_user  --name=mydb --owner=0x37Fc1953e4A26007E6Df52f06B5897a998F51f5D
 ```
 

--- a/docs/cli/databases.md
+++ b/docs/cli/databases.md
@@ -23,7 +23,7 @@ The database subcommand contains all of the commands necessary for interacting w
 
 The `deploy` subcommand is used to deploy a database schema. The `deploy` command takes no arguments, however has one required flag.  Users must specify the relative filepath to their JSON with the `--path` or `-p` flag.
 
-```
+```sh
 kwil-cli database deploy --path=./my_db.json
 ```
 
@@ -33,7 +33,7 @@ kwil-cli database deploy --path=./my_db.json
 
 The drop subcommand is used to drop a deployed database.  You can only drop databases that have been deployed with your configured wallet.  The drop command takes one argument, which is the name of the database you wish to drop.
 
-```
+```sh
 kwil-cli database drop mydb
 ```
 
@@ -42,7 +42,7 @@ kwil-cli database drop mydb
 The read subcommand is used to execute an ad-hoc SELECT statement against a database.
 This statement cannot modify state, and is therefore read-only.  It takes one argument, which is the SQL query you wish to execute.  It can be configured to point to either database ID's or databases identified by name and owner:
 
-```bash
+```sh
 kwil-cli database query 'SELECT * FROM my_table LIMIT 10' --dbid xca123
 
 kwil-cli database query 'SELECT * FROM my_table LIMIT 10' --name my_db --owner 0xabc123
@@ -52,7 +52,7 @@ kwil-cli database query 'SELECT * FROM my_table LIMIT 10' --name my_db --owner 0
 
 The list subcommand is used to list the databases deployed by a particular wallet.  This command takes no arguments, and by default will list the databases for the wallet you have configured.  You can list databases deployed from any wallet using the optional --owner (or -o) flag.
 
-```
+```sh
 kwil-cli database list --owner=0x37Fc1953e4A26007E6Df52f06B5897a998F51f5D
 ```
 
@@ -62,19 +62,19 @@ The read-schema subcommand is used to display schema information for a deployed 
 
 To select a database by its owner and name, you can use the `--owner`(or `-o`) flag, and the `--name` (or `-n`) flag.  If no `--owner` flag is provided, it will default to databases owned by the wallet you are using, if a wallet has been [configured](../cli/configuration).
 
-```
+```sh
 kwil-cli database read-schema --name=mydb
 ```
 
 or
 
-```
+```sh
 kwil-cli database read-schema --owner=0x37Fc1953e4A26007E6Df52f06B5897a998F51f5D --name=db1
 ```
 
 Alternatively, you can pass the `--dbid` flag (or `-i`)`  to identify the database to read from.
 
-```
+```sh
 kwil-cli database read-schema --dbid=xc57b99f921ac99896d861b4462d7874212e0a63e53b2c53d91b0f6d2
 ```
 
@@ -88,13 +88,13 @@ To specify the name of the query you wish to execute, you also have to pass a re
 
 Finally, in order to pass parameters to the query, you must specify the inputs as arguments.  You must first specify the name of the parameter you are filling, and then the value.  Queries should follow the layout below:
 
-```
+```sh
 kwil-cli database execute <input_name_1>:<value> <input_name_2>:<value> --action=<action_name> --dbid=<db_id>
 ```
 
 For example, if you were executing an INSERT query named "create_user" that took two parameters: name (text), and age (int), you would pass my arguments as follows:
 
-```
+```sh
 kwil-cli database execute name:satoshi age:32 --action=create_user  --name=mydb --owner=0x37Fc1953e4A26007E6Df52f06B5897a998F51f5D
 ```
 
@@ -194,8 +194,9 @@ An example that sets all batch inserted rows in the column created_at to your ma
 ```
 
 ### Example:
+
 An example usage of the batch command looks like this:
 
-```
+```bash
 kwil-cli database batch --path=./users.csv --action=create_user -m=id:id -m=full_name:name -m=age:age --dbid=xe37cbd1f883460c05d773a685b1c53b4b809f8c3794476b32e7fb5d3 --value=created_at:$(date -I seconds)
 ```

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -7,8 +7,10 @@ description: CLI Installation
 slug: /cli/installation
 ---
 
-## Install Locally 
+## Install Locally
+
 Kwil CLI binaries can be found [here.](https://github.com/kwilteam/kwil-cli/releases/tag/v0.1.2) Contained in the repo are binaries for:
+
 * Linux amd64
 * Linux arm64
 * Darwin (MacOS) amd64+arm64

--- a/docs/daemon/_category_.json
+++ b/docs/daemon/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Kwil Daemon",
-    "position": 6,
+    "position": 7,
     "link": {
         "type": "generated-index",
         "description": "Running the Kwil daemon locally"

--- a/docs/extensions/_category_.json
+++ b/docs/extensions/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Extensions",
-    "position": 5,
+    "position": 9,
     "link": {
       "type": "generated-index",
       "description": "How to build and use extensions for Kwil"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 10
 sidebar_label: "FAQ"
 id: faq
 title: FAQ

--- a/docs/links.mdx
+++ b/docs/links.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 11
 sidebar_label: "Links"
 id: links
 title: Links

--- a/docs/sdks/_category_.json
+++ b/docs/sdks/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "SDKs",
-    "position": 4,
+    "position": 5,
     "link": {
       "type": "generated-index",
       "description": "Different SDKs for using Kwil"


### PR DESCRIPTION
Initial `kwil-admin` docs.  Lots in the `node` command page is premature and likely to change since those features are not yet merged.

![image](https://github.com/kwilteam/docs/assets/140431406/1947889b-3107-42c3-873b-b0ee74136a7b)

The Installation section is best guess at this point since we should probably do two things:
- publish the kwild:latest as the images created from the kwild.script.dockerfile, which will allow entering a command prompt in the docker container
- include `kwil-admin` in the binary release archives published on https://github.com/kwilteam/kwil-cli/releases, at least until we open source the kwil-db repo