### PR TITLE
Add documentation for friendly signatures in JS SDK

### DIFF
--- a/docs/sdks/js-ts/js-ts-apis.mdx
+++ b/docs/sdks/js-ts/js-ts-apis.mdx
@@ -276,6 +276,20 @@ The following signature types can be used:
 #### Returns
 The `ActionBuilder` instance for chaining.
 
+### description()
+
+```typescript
+description(description: string): NonNil<ActionBuilder>
+```
+
+Customize the message that will be displayed in a users wallet when they sign the action.
+
+#### Parameters
+- `description`: The description to display in the user's wallet.
+
+#### Returns
+The `ActionBuilder` instance for chaining.
+
 ### buildTx()
 
 ```typescript
@@ -533,6 +547,20 @@ The `DBBuilder` class is used to build transactions for new databases to be depl
 
 Note that the DBBuilder class is not the recommended way to deploy databases on Kwil. We strongly recommend using the [Kuneiform IDE](docs/kuneiform/introduction).
 
+### payload()
+
+```typescript
+payload(payload: object): NonNil<DBBuilder>
+```
+
+Sets the payload for the database transaction. The payload must be a compiled Kuneiform file. You can create a compile Kuneiform file by right clicking a compiled file in the Kuneiform IDE and selecting "Export to JSON".
+
+#### Parameters
+- `payload`: The payload for the database transaction. This must be a valid compiled Kuneiform.
+
+#### Returns
+The `DBBuilder` instance for chaining.
+
 ### publicKey()
 
 ```typescript
@@ -570,16 +598,16 @@ The following signature types can be used:
 #### Returns
 The `DBBuilder` instance for chaining.
 
-### payload()
+### description()
 
 ```typescript
-payload(payload: object): NonNil<DBBuilder>
+description(description: string): NonNil<DBBuilder>
 ```
 
-Sets the payload for the database transaction. The payload must be a compiled Kuneiform file. You can create a compile Kuneiform file by right clicking a compiled file in the Kuneiform IDE and selecting "Export to JSON".
+Customize the message that will be displayed in a users wallet when they sign the database transaction.
 
 #### Parameters
-- `payload`: The payload for the database transaction. This must be a valid compiled Kuneiform.
+- `description`: The description to display in the user's wallet.
 
 #### Returns
 The `DBBuilder` instance for chaining.

--- a/docs/sdks/js-ts/migration.mdx
+++ b/docs/sdks/js-ts/migration.mdx
@@ -77,9 +77,11 @@ const res = await kwil.getAccount('public_key');
 
 ```
 
-### ActionBuilder and DBBuilder
+### ActionBuilder and DBBuilder + Friendly Signature Messages
 
 The ActionBuilder and DBBuilder classes now require you to chain a `.publicKey()` method to the builder. The `.publicKey()` can receive a hex string or Uint8Array. If using a NEAR public key, you may also pass the Base58 encoded public key with the "ed25519:" prefix.
+
+You can also customize the signature message that appears in metamask by chaining a `.description()` method to the builder.
 
 #### Old Version
 
@@ -103,6 +105,7 @@ const tx = await kwil
     .concat([ 'inputs', 'inputs' ])
     .publicKey('signer_public_key') // new method
     .signer(signer)
+    .description('Click sign to execute your action!') // Custom signature message.
     .buildTx();
 ```
 
@@ -202,9 +205,7 @@ const res = await kwil.call(msg);
 */
 ```
 
-If a `view` action has a `must_sign` auxiliary, you should also chain `.signer()` and `.publicKey()` methods to the builder.
-
-If you are using a NEAR signer, you must also chain the `.nearConfig()` method.
+If a `view` action has a `must_sign` auxiliary, you should also chain `.signer()` and `.publicKey()` methods to the builder. You can also chain a `.description()` to customize the signature message.
 
 ### TxInfo Endpoint
 

--- a/docs/sdks/js-ts/overview.mdx
+++ b/docs/sdks/js-ts/overview.mdx
@@ -121,6 +121,7 @@ const tx = await kwil
     .concat(input)
     .publicKey('public_key')
     .signer(await provider.getSigner()) // can use wallet if NodeJS
+    .description("Click sign to execute the action!") // your custom signature message to appear in browser wallet
     .buildTx()
 
 // broadcast transaction to kwil network
@@ -160,6 +161,7 @@ const tx = await kwil
     .concat(input)
     .publicKey(keys.publicKey)
     .signer(customSigner, 'ed25519')
+    .description("Click sign to execute the action!")
     .buildTx()
 
 await kwil.broadcast(tx);
@@ -168,6 +170,8 @@ await kwil.broadcast(tx);
 ### Reading Data
 
 To read data on Kwil, you can (1) execute a `view` action message or (2) query with the `.selectQuery()` method.
+
+If a `view` action has a `must_sign` attribute, then you must add `.signer()` and `.publicKey()` methods to the action builder. You can optionally add a `.description()` method to customize the signature message.
 
 #### `View` Action Message
 
@@ -183,7 +187,7 @@ const input = new Utils.ActionInput()
 // retrieve database ID to locate action
 const dbid = kwil.getDBID("public_key", "database_name")
 
-// construct and sign action transaction
+// construct message
 const msg = await kwil
     .actionBuilder()
     .dbid(dbid)
@@ -191,7 +195,7 @@ const msg = await kwil
     .concat(input)
     .buildMsg()
 
-// broadcast transaction to kwil network
+// call from kwil network
 const res = await kwil.call(msg)
 
 /*


### PR DESCRIPTION
Adds `.description()` method to builders, which can be used to customize signature messages sent to both the broadcast endpoint and the call endpoint.