### PR TITLE
Update introduction.md

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -11,7 +11,7 @@ slug: /introduction
 
 ## Web3 Native Decentralized Database Networks
 
-Kwil is a framework for deploying relational databases as standalone, byzantine fault tolerant networks. Kwil extends the functionality of traditional relational databases by providing a practical byanztine fault tolerant (pBFT) later on top of existing engines, enforcing rules necessary for building secure, decentralized data stores.
+Kwil is a framework for deploying relational databases as standalone, byzantine fault tolerant networks. Kwil extends the functionality of traditional relational databases by providing a practical byanztine fault tolerant (pBFT) layer on top of existing engines, enforcing rules necessary for building secure, decentralized data stores.
 
 Each Kwil network runs its own permissionless Proof-of-Stake (PoS) or permissioned Proof-of-Authority (PoA) blockchain, enabling projects to have a high-degree of configurability over their networks. With Kwil, applications and products can determine who, where, and how the nodes are run in their blockchain.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -11,13 +11,13 @@ slug: /introduction
 
 ## Web3 Native Decentralized Database Networks
 
-Kwil is a framework for deploying relational databases as standalone, byzantine fault tolerant networks. Kwil extends the functionality of traditional relational databases by providing a practical byanztine fault tolerant (pBFT) layer on top of existing engines, enforcing rules necessary for building secure, decentralized data stores.
+Kwil is a framework for leveraging relational databases as standalone, byzantine fault tolerant networks. Kwil extends the functionality of traditional relational databases by providing a practical byanztine fault tolerant (pBFT) layer on top of existing engines, enforcing rules necessary for building secure, decentralized data stores.
 
-Each Kwil network runs its own permissionless Proof-of-Stake (PoS) or permissioned Proof-of-Authority (PoA) blockchain, enabling projects to have a high-degree of configurability over their networks. With Kwil, applications and products can determine who, where, and how the nodes are run in their blockchain.
+Each Kwil network runs its own permissionless Proof-of-Stake (PoS) or permissioned Proof-of-Authority (PoA) blockchain, enabling projects to have a high-degree of configurability over their networks. With Kwil, applications and products can determine how, where, and by whom nodes are run in their blockchain
 
 **Have a question? Join our [Discord](<https://discord.com/invite/HzRPZ59Kay>)!**
 
-Kwil combines the structure and utility of a traditional OLTP database with the guarantees of blockchain networks.  Broadly speaking, users can think of Kwil networks as a relational database with the following features:
+Kwil combines the structure and utility of a traditional transactional database with the guarantees of blockchain networks.  Broadly speaking, users can think of Kwil networks as a relational database with the following features:
 
 - Secure, permissionless, deterministic relational data storage and retrieval across of a network of nodes.
 - Integrates natively with other Web3 platforms, concepts, and tooling.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -9,15 +9,17 @@ slug: /introduction
 
 ![kwil-banner](../docs/kwil-banner.svg)
 
-## The permissionless SQL database for Web3-enabled applications
+## Web3 Native Decentralized Database Networks
 
-Kwil is the first permissionless database that enables structured data storage across a decentralized network. Kwil extends the functionality of traditional relational databases by providing a layer on-top of existing engines that enforce rules necessary for building secure, permissionless data stores.
+Kwil is a framework for deploying relational databases as standalone, byzantine fault tolerant networks. Kwil extends the functionality of traditional relational databases by providing a practical byanztine fault tolerant (pBFT) later on top of existing engines, enforcing rules necessary for building secure, decentralized data stores.
+
+Each Kwil network runs its own permissionless Proof-of-Stake (PoS) or permissioned Proof-of-Authority (PoA) blockchain, enabling projects to have a high-degree of configurability over their networks. With Kwil, applications and products can determine who, where, and how the nodes are run in their blockchain.
 
 **Have a question? Join our [Discord](<https://discord.com/invite/HzRPZ59Kay>)!**
 
-Kwil combines the structure and utility of a traditional OLTP database with the guarantees of decentralized networks.  Broadly speaking, users can think of it as a relational database with the following features:
+Kwil combines the structure and utility of a traditional OLTP database with the guarantees of blockchain networks.  Broadly speaking, users can think of Kwil networks as a relational database with the following features:
 
-- Secure, permissionless, deterministic relational data storage and retrieval.
+- Secure, permissionless, deterministic relational data storage and retrieval across of a network of nodes.
 - Integrates natively with other Web3 platforms, concepts, and tooling.
 - Supports a variety of access control rules, network configurations, and value accrual mechanisms.
 
@@ -33,7 +35,6 @@ The Kwil network offers a unique method of writer access-control for application
 
 Smart contract platforms enable developers to code with programmable money.  In a Kwil database, developers are able to atomically capture the value of data to assets that exist on other blockchains.  By combining tokens with valuable data, builders are able to create new business models, value capture mechanisms, and user incentives that couldn't exist previously.
 
-
 ### Consensus
 
-The Kwil network uses CometBFT, the underlying consensus engine of the Cosmos SDK, for Practical Byzantine Fault Tolerant (PBFT) consensus.  For more information, check out the [CometBFT docs](https://docs.cometbft.com/v0.37/)
+The Kwil network uses CometBFT, the underlying consensus engine of the Cosmos SDK, for Practical Byzantine Fault Tolerant (pBFT) consensus. CometBFT is the most mature BFT consenus engine in existence. For more information, check out the [CometBFT docs](https://docs.cometbft.com/v0.37/)


### PR DESCRIPTION
I rewrote the introduction section in our docs to more clearly articulate that Kwil is a framework for deploying database networks. Previously, our public materials hinted that Kwil is a single network for database (e.g. Arweave but SQL), rather than a separate application or company-specific networks. This pull request emphasizes that there are multiple, product-specific Kwil networks.