### PR TITLE
fix(kwiljs): Update authenticate

### DIFF
--- a/docs/getting-started/read-access-control.mdx
+++ b/docs/getting-started/read-access-control.mdx
@@ -38,7 +38,7 @@ The `@kgw(authn='true')` annotation will only require the user to authenticate I
 
 ## Authenticating a User
 
-Using the JavaScript SDK and the [KwilSigner](/docs/getting-started/read-write-data#signer), a user can authenticate with the Kwil Gateway. In Browser, the cookie will be stored in the browser's cookie store. In Node.js, the cookie will be returned and then must be passed to the Kwil class.
+Using the JavaScript SDK and the [KwilSigner](/docs/getting-started/read-write-data#signer), a user can authenticate with the Kwil Gateway. When calling the `call` method, the Kwil SDK will check if the gateway is enforcing authentication. If authentication is enforced, the gateway will prompt the user to sign a message with their account keys. Once the signature is verified, the SDK will include a cookie to be passed with all subsequent requests.
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
@@ -61,9 +61,13 @@ const kwil = new WebKwil({
     chainId: "kwil-chain-testnet-0.6",
 });
 
-async function authenticateUser() {
-    const kwilSigner = await getSigner();
-    return await kwil.authenticate(kwilSigner);
+async function authenticatedAction() {
+    const payload = {
+        action: "get_profile",
+        dbid: 'x123abc...'
+    }
+
+    return await kwil.call(payload, kwilSigner); // user will be prompted to authenticate
 }
 ```
 
@@ -78,10 +82,13 @@ const kwil = new NodeKwil({
     chainId: "kwil-chain-testnet-0.6",
 });
 
-async function authenticateUser() {
-    const kwilSigner = await getSigner();
-    const res = await kwil.authenticate(kwilSigner);
-    kwil.setCookie(res.data.cookie);
+async function authenticatedAction() {
+    const payload = {
+        action: "get_profile",
+        dbid: 'x123abc...'
+    }
+
+    return await kwil.call(payload, kwilSigner); // user will be prompted to authenticate
 }
 ```
 

--- a/docs/sdks/js-ts/js-ts-apis.mdx
+++ b/docs/sdks/js-ts/js-ts-apis.mdx
@@ -39,22 +39,6 @@ Creates a new instance of the Kwil class. Can be initialized with `WebKwil` in b
 
 A new instance of the Kwil class.
 
-### authenticate()
-
-Authenticates the user with a Kwil Gateway. This method will throw an error if your Kwil Network does not have a Kwil Gateway.
-
-```typescript
-async authenticate(signer: KwilSigner): Promise<GenericResponse<AuthSuccess>>
-```
-
-#### Parameters
-
--   `signer`: The signer for the authentication transaction. This can be created with the [`KwilSigner`](#kwilsigner) class.
-
-#### Returns
-
-A promise that resolves to the authentication success or failure. If using NodeKwil, the return will also include a cookie to be passed to the [`.setCookie()`](#setcookie) method.
-
 ### call()
 
 ```typescript
@@ -70,7 +54,7 @@ interface ActionBody {
 type Entries = { [key: string]: string | number | null };
 ```
 
-Calls a `view` action on the network.
+Calls a `view` action on the network. If authentication for the view action is enforced by a Kwil Gateway, a `kwilSigner` must be provided. The call method will prompt the user to authenticate if they have not already done so, and will retain a cookie to authenticate with the Kwil Gateway for all subsequent calls.
 
 #### Parameters
 

--- a/docs/sdks/js-ts/overview.mdx
+++ b/docs/sdks/js-ts/overview.mdx
@@ -342,56 +342,19 @@ const res = await kwil.getAccount("account_identifier")
 
 ## Kwil Gateway Authentication
 
-Kwil Gateway is an optional service on Kwil networks that allows for authenticating users with their signatures for read queries. If your Kwil network used a Kwil Gateway, you can use the `kwil.authenticate()` method to authenticate users.
+Kwil Gateway is an optional service on Kwil networks that allows for authenticating users with their signatures for read queries / view actions. If your Kwil network used a Kwil Gateway, you should pass a `KwilSigner` to the `kwil.call()` method. If the user is not authenticated, the user will be prompted to sign a message to authenticate, and the SDK will automatically include the authentication cookie in each subsequent request.
 
 :::tip
 The Kwil Gateway is still in private beta.  If you would like access, please [contact](https://discord.com/invite/HzRPZ59Kay/) our team.
 :::
 
-<Tabs
-    defaultValue="js-web"
-    values={[
-        { label: 'Web', value: 'js-web', },
-        { label: 'NodeJS', value: 'js-node', },
-    ]}
->
-<TabItem value="js-web">
-
 ```javascript
-// pass the kwilSigner to the authenticate method
-const res = await kwil.authenticate(kwilSigner);
+// pass KwilSigner to the call method
+const res = await kwil.call(actionBody, kwilSigner);
 
 /*
-    res = {
-        status: 200,
-        data: {
-            result: "success"
-        }
+    res.data = {
+        result: [ query results ],
     }
 */
 ```
-
-</TabItem>
-<TabItem value="js-node">
-
-``` javascript
-// pass the kwilSigner to the authenticate method
-const res = await kwil.authenticate(kwilSigner);
-
-/*
-    res = {
-        status: 200,
-        data: {
-            result: "success",
-            cookie: "some_cookie"
-        },
-        
-    }
-*/
-
-// pass the cookie to the kwil class
-kwil.setCookie(res.data.cookie)
-```
-
-</TabItem>
-</Tabs>


### PR DESCRIPTION
Update documentation to reflect that authentication is now automatically managed by `kwil.call()`.