### PR TITLE
fix: broken `id` link

### DIFF
--- a/docs/cli/kwil-cli/account/index.md
+++ b/docs/cli/kwil-cli/account/index.md
@@ -36,6 +36,6 @@ Commands related to Kwil account, such as balance checks and transfers.
 
 * [kwil-cli](/docs/ref/kwil-cli)	 - Command line interface for using Kwil databases.
 * [kwil-cli account balance](/docs/ref/kwil-cli/account/balance)	 - Gets an account's balance and nonce
-* [kwil-cli account id](/docs/ref/kwil-cli/account/i)	 - Show the account ID.
+* [kwil-cli account id](/docs/ref/kwil-cli/account/id)	 - Show the account ID.
 * [kwil-cli account transfer](/docs/ref/kwil-cli/account/transfer)	 - Transfer value to an account
 

--- a/docs/cli/kwil-cli/database/batch.mdx
+++ b/docs/cli/kwil-cli/database/batch.mdx
@@ -16,7 +16,7 @@ Batch execute an action using inputs from a CSV file.
 Batch executes an action on a database using inputs from a CSV file.
 
 To map a CSV column name to an action input, use the `--map-inputs` flag.
-The format is `--map-inputs <csv_column_1>:<action_input_1>,<csv_column_2>:<action_input_2>`.  If the `--map-inputs` flag is not passed,
+The format is `--map-inputs "<csv_column_1>:<action_input_1>,<csv_column_2>:<action_input_2>"`.  If the `--map-inputs` flag is not passed,
 the CSV column name will be used as the action input name.
 	
 You can also specify the input values directly using the `--values` flag, delimited by a colon.


### PR DESCRIPTION
@brennanjl do you want to check why the autogen docs have the wrong id link?