### PR TITLE
postgresql updates to Node Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ After you’ve tested your changes:
 
 Return to the Kwil docs home page in GitHub and navigate to [Pull Requests](https://github.com/kwilteam/docs/pulls).
 
-Click the Compare and pull request button, add a brief description of the changes made, including a motivation for why this will benefit the Kwil community, and then finally click the Create pull request button.
+Click the create pull request button, add a brief description of the changes made, including a motivation for why this will benefit the Kwil community, and then finally click the Create pull request button.
 
 All pull requests will be reviewed as soon as possible, and if accepted, will be merged and published.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For minor edits to the existing Kwil docs, e.g., fixing typos, or adding small p
 
 - Use GitHub to edit the page to which you wish to contribute, using markdown
 
-- Push the changes to a new branch 
+- Push the changes to a new branch
 
 - Issue a pull request into the Kwil docs repository
 
@@ -38,13 +38,13 @@ If you use git https:
 
 where `GITUSERNAME` is your git profile handle.
 
-### Install Node v16.14 or Above
+### Install Node 20.9 or Above
 
-Docusaurus requires Node v16.14 or above.
+Docusaurus requires Node v20.9 or above.
 
 Kwil recommends you use [nvm](https://github.com/nvm-sh/nvm) to manage your node.js environments.
 
-`nvm install 16.14`
+`nvm install 20`
 
 ### Use NPM to fetch package dependencies
 
@@ -64,7 +64,7 @@ This step should start the node development server and launch a web browser to t
 
 ## Adding your contribution to Kwil docs
 
-You will need to familiarize yourself with the Docusaurus file layout, categorization, and other features. 
+You will need to familiarize yourself with the Docusaurus file layout, categorization, and other features.
 Docusaurus provide an interactive [sandbox Playground](https://docusaurus.io/docs/playground) that will help you get up to speed.
 
 When ready, use your favourite Node.js IDE tooling, e.g., VS Code, to add new pages, React.js scripts, CSS styles etc., in accordance with Docusaurus guidelines.
@@ -77,7 +77,9 @@ After you’ve tested your changes:
 
 `git add .`
 
-- Commit your changes to a new branch. 
+  Note that the above command will add all untracked files, so check for unintended additions.  Otherwise, use `git add -u`, and add new files explicitly.
+
+- Commit your changes to a new branch.
 
 `git commit -m "Add new section for new feature XYZ"`
 
@@ -89,10 +91,8 @@ After you’ve tested your changes:
 
 Return to the Kwil docs home page in GitHub and navigate to [Pull Requests](https://github.com/kwilteam/docs/pulls).
 
-Click the Compare and pull request button, add a brief description of the changes made, including a motivation for why this will benefit the Kwil community, and then finally click the Create pull request button. 
+Click the Compare and pull request button, add a brief description of the changes made, including a motivation for why this will benefit the Kwil community, and then finally click the Create pull request button.
 
 All pull requests will be reviewed as soon as possible, and if accepted, will be merged and published.
 
 Thank you for your contribution!
-
-

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -37,4 +37,4 @@ Smart contract platforms enable developers to code with programmable money.  In 
 
 ### Consensus
 
-The Kwil network uses CometBFT, the underlying consensus engine of the Cosmos SDK, for Practical Byzantine Fault Tolerant (pBFT) consensus. CometBFT is the most mature BFT consensus engine in existence. For more information, check out the [CometBFT docs](https://docs.cometbft.com/v0.37/)
+The Kwil network uses CometBFT, the underlying consensus engine of the Cosmos SDK, for Practical Byzantine Fault Tolerant (pBFT) consensus. CometBFT is the most mature BFT consensus engine in existence. For more information, check out the [CometBFT docs](https://docs.cometbft.com/v0.38/)

--- a/docs/node/daemon/config/settings.mdx
+++ b/docs/node/daemon/config/settings.mdx
@@ -27,7 +27,15 @@ This section holds configurations specific to the Kwil application's operation.
 
 - `admin_listen_addr`: This variable specifies the address where the daemon's admin gRPC server listens for connections. The default is `localhost:50151`.
 
-- `sqlite_file_path`: This variable specifies the path for SQLite files. If left unspecified, it defaults to `data/kwil.db/` relative to the root directory.
+- `pg_db_host`: PostgreSQL database host (UNIX socket path or IP address with no port). The default is `/var/run/postgresql`.
+
+- `pg_db_port`: PostgreSQL database port (may be omitted for UNIX socket hosts). The default is `5432`.
+
+- `pg_db_user`: PostgreSQL database user (should be a "superuser"). The default is `kwild`.
+
+- `pg_db_pass`: PostgreSQL database pass (may be omitted for some pg_hba.conf configurations).
+
+- `pg_db_name`: PostgreSQL database name (override database name). The default is `kwild`.
 
 - `private_key_path`: This variable specifies the path for node's private key. If left unspecified, it defaults to `./private_key` relative to the root directory.
 
@@ -124,8 +132,6 @@ Here is an example of a `config.toml` file with complete configuration:
 #   |   |- data/          (blockchain files: blockstore.db, state.db, etc)
 #   |   |- info/
 #   |- application/
-#   |- data
-#   |   |- kwild.db/
 #   |- signing/
 
 # Required files: config.toml, private_key, and genesis files
@@ -169,8 +175,20 @@ admin_listen_addr = "localhost:50151"
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = []
 
-# KWILD Sqlite database file path
-sqlite_file_path = "data/kwild.db"
+# PostgreSQL database host (UNIX socket path or IP address with no port)
+pg_db_host = "/var/run/postgresql"
+
+# PostgreSQL database port (may be omitted for UNIX socket hosts)
+pg_db_port = "5432"
+
+# PostgreSQL database user (should be a "superuser")
+pg_db_user = "kwild"
+
+# PostgreSQL database pass (may be omitted for some pg_hba.conf configurations)
+pg_db_pass = ""
+
+# PostgreSQL database name (override database name, default is "kwild")
+pg_db_name = "kwild"
 
 # The path to a file containing certificate that is used to enable TLS on the gRPC server.
 # Might be either absolute path or path related to the kwild root directory.

--- a/docs/node/daemon/install.mdx
+++ b/docs/node/daemon/install.mdx
@@ -34,6 +34,17 @@ Kwil DB is built on PostgreSQL, and requires an external PostgreSQL host running
 `kwild` currently requires PostgreSQL 16, from at least v16.1. Future major
 versions will require an update to Kwil.
 
+### Quickstart PostgreSQL
+
+For quick usage, Kwil provides a Docker image with a properly configured
+PostgreSQL instance. This is convenient for quick setup of a Kwil node, but is
+less configurable than a system service. The following command will pull and
+start a new container:
+
+```bash
+docker run -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 kwildb/postgres
+```
+
 ### PostgreSQL Installation
 
 Standard PostgreSQL installers and operating system packages are supported,

--- a/docs/node/daemon/install.mdx
+++ b/docs/node/daemon/install.mdx
@@ -136,7 +136,7 @@ required, **skip this section** and proceed to [Running `kwild`](#running-kwild)
 If using any other installation of PostgreSQL such as from an operating system
 package manager, it is necessary to change a few settings in the
 `postgresql.conf` file. Once reconfigured, it may also be necessary to create a
-new database and "role" to match the `kwild`'d configuration.
+new database and "role" to match `kwild`'s configuration.
 
 #### PostgreSQL Settings
 

--- a/docs/node/daemon/install.mdx
+++ b/docs/node/daemon/install.mdx
@@ -37,43 +37,25 @@ versions will require an update to Kwil.
 ### PostgreSQL Installation
 
 Standard PostgreSQL installers and operating system packages are supported,
-given a supported version. We also provide Docker Compose service definitions
-with the required settings, roles, and databases pre-configured for ease of
-deployment and evaluation.
+given a supported version. We also provide Docker images and Compose service
+definitions with the required settings, roles, and databases pre-configured for
+ease of deployment and evaluation.
 
-The recommended options are as follows.
+The recommended options are:
 
-1. System installation of `postgres`. This requires some manual configuration.
-2. The `postgres` Docker Compose service provided in the
-   `deployments/compose/postgres` folder in the [`kwil-db` source code repository](https://github.com/kwilteam/kwil-db).
-   This is pre-configured for `kwild` and is convenient for quick setup, but
-   may be less reliable or secure than a manually configured `postgres` instance.
-3. The `kwil` Docker Compose services provided in
-   `deployments/compose/kwil`. This launches both a `postgres` service
-   and a `kwild` service in "quickstart" mode with the `--autogen` flag. This is
-   only for testing and evaluation as it uses new randomly generate chain ID and
-   validator private key.
-
-Docker Engine and the Docker Compose plugin (or just Docker Desktop) are required for
-the two Docker options. With the Docker daemon running, either service may be
-started by running the following from the appropriate folder in the repository:
-
-```sh
-$ docker compose up -d
-```
-
-With the `-d` option, the service(s) will be started as background processes. To
-stop them or view logs, use the `docker container` commands or the Docker
-Desktop dashboard.
+* System installation of `postgres`. This requires some manual configuration.
+* The [`kwildb/postgres`](https://hub.docker.com/r/kwildb/postgres) Docker image
+  on Docker Hub. It is pre-configured for `kwild` and is convenient for quick
+  setup, but may be less reliable or secure than a manually configured
+  `postgres` instance.
 
 :::info
 If a user-provided installation of PostgreSQL, such as an operating system
 `postgres` package, is used, the configuration must be changed as described in [PostgreSQL Configuration](#postgresql-configuration).
 :::
 
-If you start the Docker service from `deployments/compose/postgres`, you may
-skip to [Running `kwild`](#running-kwild).
-
+See also the [README](https://github.com/kwilteam/kwil-db/blob/main/README.md)
+for other convenient methods for developers to start test nodes or networks.
 
 #### System Install
 
@@ -99,18 +81,27 @@ with an entry for `"postgresql-*"`.
 Finally, a system install of `postgres` requires making some configuration
 changes to support `kwild`. These are described in the [PostgreSQL Configuration](#postgresql-configuration) section.
 
-#### Docker Service
+#### Docker Image
 
-In the [`kwil-db` source code repository](https://github.com/kwilteam/kwil-db),
-the `deployments/compose/postgres` folder contains a Docker Compose definition
-for a `postgres` service. This is convenient for quick setup of a Kwil node,
-but is less configurable than a system service.
+The [`kwildb/postgres`](https://hub.docker.com/r/kwildb/postgres) Docker image
+is available on Docker Hub. This is convenient for quick setup of a Kwil node,
+but is less configurable than a system service. The following command will pull
+and start a new container:
 
-This service is pre-configured for `kwild`, and automatically creates a
-`"kwild"` database owned by a `"kwild"` role that will work with the default
-`kwild` settings.  However, this requires the Docker engine running and
-configured so that the `postgres` service has sufficient disk, CPU, and memory
-resources for demand of the application.
+```bash
+docker run -p 5432:5432 -v kwil-pgdata:/var/lib/postgresql/data --shm-size 256m \
+    -e "POSTGRES_HOST_AUTH_METHOD=trust" kwildb/postgres:latest
+```
+
+The above will start a pre-configured `postgres` in a Docker container, using a
+persistent Docker volume named `kwil-pgdata`. To require authentication, use
+`"POSTGRES_PASSWORD=mypass"` to set the `postgres` superuser password instead
+of `"POSTGRES_HOST_AUTH_METHOD=trust"`.
+
+This service automatically creates a `"kwild"` database owned by a `"kwild"`
+role. The password for this user is initially `"kwild"`, which would be
+specified with the `app.pg-db-pass` flag if not using "trust" authentication.
+Use [`psql`](https://www.postgresql.org/docs/current/app-psql.html) if you wish to change it.
 
 :::note
 This service exposes `postgres` on port 5432 of the *host* machine so that it
@@ -121,23 +112,9 @@ already listening on port 5432.
 
 A persistent Docker volume called `postgres_kwildb` will be created. If
 resetting `kwild`'s data folders, it is also necessary to delete this volume.
-
-#### Unified `kwild` + `postgres` Quickstart Services
-
-The `deployments/compose/kwil` folder of the `kwil-db` repository
-contains another Docker Compose service definition that is geared toward "quick
-start" use cases and development.  This services for both `kwild` and
-`postgres`, configured so that they will work together out-of-the-box with no
-additional configuration changes.
-
-With this approach, `kwild` is started with the `--autogen` flag, as used in the
-Quickstart guide for demonstrating Kwil DB use. This creates a new randomly
-generate chain, and is not intended for production use. However, the service
-definition may be used as a basis for a customized deployment.
-
-On start, this service definition will create a `testnode` folder in the same
-location as the `docker-compose.yml` file, and a persistent Docker volume called
-`kwil_pgkwil` for the `postgres` database cluster files.
+Ensure that the Docker Engine is running and configured so that the `postgres`
+service has sufficient disk, CPU, and memory resources for demand of your
+application.
 
 ### PostgreSQL Configuration
 

--- a/docs/node/daemon/install.mdx
+++ b/docs/node/daemon/install.mdx
@@ -14,7 +14,7 @@ The Kwil command line applications may be downloaded from the
 
 The Kwil daemon (`kwild`) will be packaged together with Kwil node admin tool (`kwil-admin`) and Kwil CLI (`kwil-cli`).
 Download the [latest release](https://github.com/kwilteam/binary-releases/releases)
-for your platform.  Extract these three executable files from the archive and put it
+for your platform.  Extract these three executable files from the archive and put them
 into a folder that is in your `PATH` environment.
 
 ## Verify Installation
@@ -31,16 +31,14 @@ If installed correctly, the displayed version info should match your downloaded 
 
 Kwil DB is built on PostgreSQL, and requires an external PostgreSQL host running and configured for `kwild`.
 
-`kwild` can connect to `postgres`, the PostgreSQL process, using either TCP/IP or a UNIX socket.
-
-Kwil currently requires PostgreSQL 16, from at least v16.1. Support for future
-major versions will require an update to Kwil.
+`kwild` currently requires PostgreSQL 16, from at least v16.1. Future major
+versions will require an update to Kwil.
 
 ### PostgreSQL Installation
 
 Standard PostgreSQL installers and operating system packages are supported,
-given a supported version. We provide Docker Compose service definitions with
-the required settings, roles, and databases pre-configured for ease of
+given a supported version. We also provide Docker Compose service definitions
+with the required settings, roles, and databases pre-configured for ease of
 deployment and evaluation.
 
 The recommended options are as follows.
@@ -73,6 +71,9 @@ If a user-provided installation of PostgreSQL, such as an operating system
 `postgres` package, is used, the configuration must be changed as described in [PostgreSQL Configuration](#postgresql-configuration).
 :::
 
+If you start the Docker service from `deployments/compose/postgres`, you may
+skip to [Running `kwild`](#running-kwild).
+
 
 #### System Install
 
@@ -80,14 +81,20 @@ An operator may use a system installation of `postgres` from one of the
 [official PostgreSQL installers](https://www.postgresql.org/download/) or
 operating system packages managers.
 
-:::tip
-It is recommended to use a postgresql.org repository, such as the "pgdg" Ubuntu
-Apt Repository rather than the operating system's own packages.
-:::
-
 Be sure to install version-specific packages, such as `postgresql-16`, rather than
 a metapackage that will automatically install the latest major version, which may
 not be supported by Kwil.
+
+:::tip
+It is recommended to use a postgresql.org repository, such as the ["pgdg" Ubuntu
+Apt Repository](https://wiki.postgresql.org/wiki/Apt) rather than the operating system's own packages.
+
+Also, be sure any unattended upgrades exclude the PostgreSQL package to prevent
+it from restarting while in used. For instance, on Debian-based systems,
+configure
+[`Unattended-Upgrade::Package-Blacklist`](https://help.ubuntu.com/community/AutomaticSecurityUpdates#Using_the_.22unattended-upgrades.22_package).
+with an entry for `"postgresql-*"`.
+:::
 
 Finally, a system install of `postgres` requires making some configuration
 changes to support `kwild`. These are described in the [PostgreSQL Configuration](#postgresql-configuration) section.
@@ -115,9 +122,9 @@ already listening on port 5432.
 A persistent Docker volume called `postgres_kwildb` will be created. If
 resetting `kwild`'s data folders, it is also necessary to delete this volume.
 
-#### Combined Quickstart Docker Services
+#### Unified `kwild` + `postgres` Quickstart Services
 
-The `deployments/compose/postgres/kwil` folder of the `kwil-db` repository
+The `deployments/compose/kwil` folder of the `kwil-db` repository
 contains another Docker Compose service definition that is geared toward "quick
 start" use cases and development.  This services for both `kwild` and
 `postgres`, configured so that they will work together out-of-the-box with no
@@ -132,8 +139,75 @@ On start, this service definition will create a `testnode` folder in the same
 location as the `docker-compose.yml` file, and a persistent Docker volume called
 `kwil_pgkwil` for the `postgres` database cluster files.
 
-## PostgreSQL Configuration
+### PostgreSQL Configuration
 
+When using one of the Docker Compose service definitions described in the
+previous section, no changes to the `postgres` process configuration are
+required, **skip this section** and proceed to [Running `kwild`](#running-kwild).
+
+If using any other installation of PostgreSQL such as from an operating system
+package manager, it is necessary to change a few settings in the
+`postgresql.conf` file. Once reconfigured, it may also be necessary to create a
+new database and "role" to match the `kwild`'d configuration.
+
+#### PostgreSQL Settings
+
+`kwild` requires some changes to the default `postgres` configuration:
+
+- `wal_level` set to `"logical"` to enable logical replication functionality
+- `max_wal_senders` at least `10`
+- `max_replication_slots` at least `10`
+- `max_prepared_transactions` at least 2 for two-phase commit capability
+
+In addition to the above non-default settings, `kwild` will also verify the
+following settings, which are satisfied by `postgres` defaults:
+
+- `synchronous_commit = on`
+- `fsync = on`
+- `max_connections` at least `50` (the default is usually 100)
+
+:::tip
+It is recommended to enable data checksums on the database cluster.
+See the [documentation](https://www.postgresql.org/docs/current/checksums.html) for more information.
+The provided Docker Compose services do this automatically.
+:::
+
+#### PostgreSQL Initialization
+
+Depending on `kwild` configuration, is may be necessary to create a `postgres`
+[role](https://www.postgresql.org/docs/16/user-manag.html) and
+[database](https://www.postgresql.org/docs/16/manage-ag-overview.html).
+
+The relevant `kwild` settings are:
+
+- `app.pg-db-host` is the host name for the `postgres` server. Default is
+  127.0.0.1, but may also be a path to a UNIX socket such as `/var/run/postgresql`.
+  Most PostgreSQL packages are configured to listen on both by default.
+- `app.pg_db_port` is the TCP port for the `postgres` server. Default is 5432.
+  This setting is ignored if a UNIX socket is used for `app.pg-db-host`.
+- `app.pg_db_user` is the name of the role (like a user). Default is `kwild`.
+- `app.pg_db_pass` is the password for the role specified by `app.pg_db_user`.
+  Default is unset. Required if a password is set for the role, and not using
+  "trust" authentication.
+
+Use the `psql` command to connect to `postgres` and create the specified role and
+database. For example, to create a "superuser" role named `"kwild"` with the
+password `"kwild"`, and a database called `"kwild"` owned by that role:
+
+```sql
+CREATE USER kwild WITH PASSWORD 'kwild' SUPERUSER REPLICATION;
+CREATE DATABASE kwild OWNER kwild;
+```
+
+:::warning
+`kwild` currently requires a "superuser" role to perform various
+tasks that require elevated privileges, such as creating triggers and
+publications for logical replication. The `postgres` database cluster
+should be dedicated to `kwild`, and should not be used for any other purpose.
+:::
+
+For more information about authentication configuration please see
+the official [PostgreSQL documentation](https://www.postgresql.org/docs/16/auth-pg-hba-conf.html).
 
 ## Running `kwild`
 

--- a/docs/node/daemon/install.mdx
+++ b/docs/node/daemon/install.mdx
@@ -13,8 +13,7 @@ The Kwil command line applications may be downloaded from the
 ## Download the `kwild` Executable
 
 The Kwil daemon (`kwild`) will be packaged together with Kwil node admin tool (`kwil-admin`) and Kwil CLI (`kwil-cli`).
-Download the [latest release](https://github.com/kwilteam/binary-releases/releases)
-for your platform.  Extract these three executable files from the archive and put them
+Download the latest release for your platform.  Extract these three executable files from the archive and put them
 into a folder that is in your `PATH` environment.
 
 ## Verify Installation
@@ -29,9 +28,7 @@ If installed correctly, the displayed version info should match your downloaded 
 
 ## PostgreSQL
 
-Kwil DB is built on PostgreSQL, and requires an external PostgreSQL host running and configured for `kwild`.
-
-`kwild` currently requires PostgreSQL 16, from at least v16.1. Future major
+Kwil is built on PostgreSQL, and requires an external PostgreSQL host running and configured for `kwild`. `kwild` currently requires PostgreSQL 16, from at least v16.1. Future major
 versions will require an update to Kwil.
 
 ### Quickstart PostgreSQL
@@ -42,15 +39,15 @@ less configurable than a system service. The following command will pull and
 start a new container:
 
 ```bash
-docker run -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 kwildb/postgres
+docker run -p 5432:5432 --name kwil-postgres -e "POSTGRES_HOST_AUTH_METHOD=trust" \ 
+    kwildb/postgres:latest
 ```
 
 ### PostgreSQL Installation
 
-Standard PostgreSQL installers and operating system packages are supported,
-given a supported version. We also provide Docker images and Compose service
-definitions with the required settings, roles, and databases pre-configured for
-ease of deployment and evaluation.
+Standard PostgreSQL installers and operating system packages are supported.
+We also provide Docker images and Compose service definitions with the required
+settings, roles, and databases pre-configured for ease of deployment and evaluation.
 
 The recommended options are:
 
@@ -65,7 +62,7 @@ If a user-provided installation of PostgreSQL, such as an operating system
 `postgres` package, is used, the configuration must be changed as described in [PostgreSQL Configuration](#postgresql-configuration).
 :::
 
-See also the [README](https://github.com/kwilteam/kwil-db/blob/main/README.md)
+See the [README](https://github.com/kwilteam/kwil-db/blob/main/README.md)
 for other convenient methods for developers to start test nodes or networks.
 
 #### System Install
@@ -111,10 +108,10 @@ of `"POSTGRES_HOST_AUTH_METHOD=trust"`.
 
 This service automatically creates a `"kwild"` database owned by a `"kwild"`
 role. The password for this user is initially `"kwild"`, which would be
-specified with the `app.pg-db-pass` flag if not using "trust" authentication.
+specified with the `kwild` flag `--app.pg-db-pass` flag if not using "trust" authentication.
 Use [`psql`](https://www.postgresql.org/docs/current/app-psql.html) if you wish to change it.
 
-:::note
+:::info
 This service exposes `postgres` on port 5432 of the *host* machine so that it
 may be accessed for administrative purposes from the host machine via `psql`.
 This means that it will fail to start if there is a process on the host machine
@@ -129,7 +126,7 @@ application.
 
 ### PostgreSQL Configuration
 
-When using one of the Docker Compose service definitions described in the
+When using Kwil's Postgres Docker image (`kwildb/postgres`) or one of the Docker Compose service definitions described in the
 previous section, no changes to the `postgres` process configuration are
 required, **skip this section** and proceed to [Running `kwild`](#running-kwild).
 
@@ -171,10 +168,10 @@ The relevant `kwild` settings are:
 - `app.pg-db-host` is the host name for the `postgres` server. Default is
   127.0.0.1, but may also be a path to a UNIX socket such as `/var/run/postgresql`.
   Most PostgreSQL packages are configured to listen on both by default.
-- `app.pg_db_port` is the TCP port for the `postgres` server. Default is 5432.
+- `app.pg-db-port` is the TCP port for the `postgres` server. Default is 5432.
   This setting is ignored if a UNIX socket is used for `app.pg-db-host`.
-- `app.pg_db_user` is the name of the role (like a user). Default is `kwild`.
-- `app.pg_db_pass` is the password for the role specified by `app.pg_db_user`.
+- `app.pg-db-user` is the name of the role (like a user). Default is `kwild`.
+- `app.pg-db-pass` is the password for the role specified by `app.pg-db-user`.
   Default is unset. Required if a password is set for the role, and not using
   "trust" authentication.
 

--- a/docs/node/daemon/install.mdx
+++ b/docs/node/daemon/install.mdx
@@ -3,18 +3,18 @@ sidebar_position: 1
 sidebar_label: "Installation"
 id: daemon-installation
 title: Installation
-description: How to install the Kwil Daemon tool
+description: How to install the Kwil daemon
 slug: /daemon/installation
 ---
 
-Until the main Kwil DB repository is open source, the `kwild` command line
-application may be downloaded from the Kwil binary release repository.
+The Kwil command line applications may be downloaded from the
+[latest GitHub release](https://github.com/kwilteam/kwil-db/releases/latest).
 
 ## Download the `kwild` Executable
 
-The Kwil Daemon (`kwild`) will be packaged together with Kwil Admin Tool (`kwil-admin`) and Kwil Cli (`kwil-cli`).
+The Kwil daemon (`kwild`) will be packaged together with Kwil node admin tool (`kwil-admin`) and Kwil CLI (`kwil-cli`).
 Download the [latest release](https://github.com/kwilteam/binary-releases/releases)
-for your platform.  Extract the `kwild` file from the archive and put it
+for your platform.  Extract these three executable files from the archive and put it
 into a folder that is in your `PATH` environment.
 
 ## Verify Installation
@@ -25,6 +25,116 @@ Open a terminal and run the following at the command prompt:
 kwild --version
 ```
 
-If installed correctly, it should display the version info match your downloaded version.
+If installed correctly, the displayed version info should match your downloaded version.
+
+## PostgreSQL
+
+Kwil DB is built on PostgreSQL, and requires an external PostgreSQL host running and configured for `kwild`.
+
+`kwild` can connect to `postgres`, the PostgreSQL process, using either TCP/IP or a UNIX socket.
+
+Kwil currently requires PostgreSQL 16, from at least v16.1. Support for future
+major versions will require an update to Kwil.
+
+### PostgreSQL Installation
+
+Standard PostgreSQL installers and operating system packages are supported,
+given a supported version. We provide Docker Compose service definitions with
+the required settings, roles, and databases pre-configured for ease of
+deployment and evaluation.
+
+The recommended options are as follows.
+
+1. System installation of `postgres`. This requires some manual configuration.
+2. The `postgres` Docker Compose service provided in the
+   `deployments/compose/postgres` folder in the [`kwil-db` source code repository](https://github.com/kwilteam/kwil-db).
+   This is pre-configured for `kwild` and is convenient for quick setup, but
+   may be less reliable or secure than a manually configured `postgres` instance.
+3. The `kwil` Docker Compose services provided in
+   `deployments/compose/kwil`. This launches both a `postgres` service
+   and a `kwild` service in "quickstart" mode with the `--autogen` flag. This is
+   only for testing and evaluation as it uses new randomly generate chain ID and
+   validator private key.
+
+Docker Engine and the Docker Compose plugin (or just Docker Desktop) are required for
+the two Docker options. With the Docker daemon running, either service may be
+started by running the following from the appropriate folder in the repository:
+
+```sh
+$ docker compose up -d
+```
+
+With the `-d` option, the service(s) will be started as background processes. To
+stop them or view logs, use the `docker container` commands or the Docker
+Desktop dashboard.
+
+:::info
+If a user-provided installation of PostgreSQL, such as an operating system
+`postgres` package, is used, the configuration must be changed as described in [PostgreSQL Configuration](#postgresql-configuration).
+:::
+
+
+#### System Install
+
+An operator may use a system installation of `postgres` from one of the
+[official PostgreSQL installers](https://www.postgresql.org/download/) or
+operating system packages managers.
+
+:::tip
+It is recommended to use a postgresql.org repository, such as the "pgdg" Ubuntu
+Apt Repository rather than the operating system's own packages.
+:::
+
+Be sure to install version-specific packages, such as `postgresql-16`, rather than
+a metapackage that will automatically install the latest major version, which may
+not be supported by Kwil.
+
+Finally, a system install of `postgres` requires making some configuration
+changes to support `kwild`. These are described in the [PostgreSQL Configuration](#postgresql-configuration) section.
+
+#### Docker Service
+
+In the [`kwil-db` source code repository](https://github.com/kwilteam/kwil-db),
+the `deployments/compose/postgres` folder contains a Docker Compose definition
+for a `postgres` service. This is convenient for quick setup of a Kwil node,
+but is less configurable than a system service.
+
+This service is pre-configured for `kwild`, and automatically creates a
+`"kwild"` database owned by a `"kwild"` role that will work with the default
+`kwild` settings.  However, this requires the Docker engine running and
+configured so that the `postgres` service has sufficient disk, CPU, and memory
+resources for demand of the application.
+
+:::note
+This service exposes `postgres` on port 5432 of the *host* machine so that it
+may be accessed for administrative purposes from the host machine via `psql`.
+This means that it will fail to start if there is a process on the host machine
+already listening on port 5432.
+:::
+
+A persistent Docker volume called `postgres_kwildb` will be created. If
+resetting `kwild`'s data folders, it is also necessary to delete this volume.
+
+#### Combined Quickstart Docker Services
+
+The `deployments/compose/postgres/kwil` folder of the `kwil-db` repository
+contains another Docker Compose service definition that is geared toward "quick
+start" use cases and development.  This services for both `kwild` and
+`postgres`, configured so that they will work together out-of-the-box with no
+additional configuration changes.
+
+With this approach, `kwild` is started with the `--autogen` flag, as used in the
+Quickstart guide for demonstrating Kwil DB use. This creates a new randomly
+generate chain, and is not intended for production use. However, the service
+definition may be used as a basis for a customized deployment.
+
+On start, this service definition will create a `testnode` folder in the same
+location as the `docker-compose.yml` file, and a persistent Docker volume called
+`kwil_pgkwil` for the `postgres` database cluster files.
+
+## PostgreSQL Configuration
+
+
+## Running `kwild`
 
 Continue to the [Using Kwild](/docs/daemon/kwild) page for running Kwil node.

--- a/docs/node/daemon/kwild.mdx
+++ b/docs/node/daemon/kwild.mdx
@@ -24,6 +24,11 @@ home_dir/
 
 The default root directory is `~/.kwild`. You can override this configuration by setting the `KWILD_ROOT_DIR` environment variable or using the `--root-dir` command line flag.
 
+## Requirements
+
+The `kwild` commands on this page assume you have configured a PostgreSQL host
+as described in [Installation](/docs/daemon/installation).
+
 ## Quickstart
 
 Quickstart mode can be used to swiftly deploy a node without delving into the configuration details.  To run in this mode, use the `kwild` command with the `--autogen` flag.

--- a/docs/node/quickstart.mdx
+++ b/docs/node/quickstart.mdx
@@ -12,6 +12,10 @@ slug: /node/quickstart
 To run either a single Kwil node, or a network of nodes, you will need to download the binaries.  Kwil releases
 binaries on [Github](<https://github.com/kwilteam/binary-releases/releases>).
 
+Kwil also requires a dedicate PostgreSQL host configured for `kwild`.
+
+See the Installation (link!) page for details.
+
 ## Single Node
 
 To run a single node, simply use the `kwild` binary with the `--autogen` flag.  This will automatically generate a
@@ -20,6 +24,12 @@ genesis file, private key, and more in the `~/.kwild` directory.
 ```bash
 kwild --autogen
 ```
+
+:::note
+The `--autogen` flag generates a random chain ID, which is the network's identity, as well as a new initial validator private key.
+The node will be the one initial validator.
+As such, this mode is primarily useful for a quick deployment for evaluation and testing; production networks will define their own chain ID and initial validator set.
+:::
 
 ## Multi-Node
 
@@ -32,6 +42,9 @@ To generate the configs for 3 validators in `./kwil-testnet`, run:
 ```bash
 kwil-admin setup testnet -v 3 --hostnames "localhost,localhost,localhost" --output-dir ./kwil-testnet
 ```
+
+This creates three nodes that can run on the same host for evaluation.
+A production network would comprise nodes on different machines, but with the same `genesis.json` file.
 
 ### Run Nodes
 

--- a/docs/node/quickstart.mdx
+++ b/docs/node/quickstart.mdx
@@ -14,7 +14,7 @@ binaries on [Github](<https://github.com/kwilteam/binary-releases/releases>).
 
 Kwil also requires a dedicate PostgreSQL host configured for `kwild`.
 
-See the Installation (link!) page for details.
+See the [Installation](/docs/daemon/installation) page for details.
 
 ## Single Node
 

--- a/docs/node/quickstart.mdx
+++ b/docs/node/quickstart.mdx
@@ -7,6 +7,11 @@ description: Quickstart guide for running a node
 slug: /node/quickstart
 ---
 
+This page demonstrates Kwil DB in both single node and multi-node configurations
+using new randomly generated chains and validator keys. Use this to evaluate and
+test `kwild`. To prepare a production deployment, see
+[Installation](/docs/daemon/installation) and [Running a Kwil Node](/docs/daemon/kwild)
+
 ## Installation
 
 To run either a single Kwil node, or a network of nodes, you will need to download the binaries.  Kwil releases
@@ -18,8 +23,17 @@ See the [Installation](/docs/daemon/installation) page for details.
 
 ## Single Node
 
-To run a single node, simply use the `kwild` binary with the `--autogen` flag.  This will automatically generate a
-genesis file, private key, and more in the `~/.kwild` directory.
+First ensure that PostgreSQL is running and configured for `kwild`. See
+[Installation](/docs/daemon/installation) for details. For the quickstart, just:
+
+```bash
+docker run -p 5432:5432 -v kwil-pgdata:/var/lib/postgresql/data --shm-size 256m \
+    -e "POSTGRES_HOST_AUTH_METHOD=trust" kwildb/postgres:latest
+```
+
+To run a single node, simply use the `kwild` binary with the `--autogen` flag.
+This will automatically generate a genesis file, private key, and more in the
+`~/.kwild` directory.
 
 ```bash
 kwild --autogen
@@ -30,6 +44,9 @@ The `--autogen` flag generates a random chain ID, which is the network's identit
 The node will be the one initial validator.
 As such, this mode is primarily useful for a quick deployment for evaluation and testing; production networks will define their own chain ID and initial validator set.
 :::
+
+To clean up when done testing, delete the `~/.kwild` folder and the
+`kwil-pgdata` Docker volume.
 
 ## Multi-Node
 
@@ -48,20 +65,51 @@ A production network would comprise nodes on different machines, but with the sa
 
 ### Run Nodes
 
+First start `postgres` containers for each of the nodes. Use the following
+commands to start all three running in the background, with different named
+volumes, and listening on ports 5440-5442.
+
+```bash
+docker run -p 5440:5432 -v kwil0-testnet-pgdata:/var/lib/postgresql/data --shm-size 256m \
+    -e "POSTGRES_HOST_AUTH_METHOD=trust" --name node0 -d kwildb/postgres:latest
+docker run -p 5441:5432 -v kwil1-testnet-pgdata:/var/lib/postgresql/data --shm-size 256m \
+    -e "POSTGRES_HOST_AUTH_METHOD=trust" --name node1 -d kwildb/postgres:latest
+docker run -p 5442:5432 -v kwil2-testnet-pgdata:/var/lib/postgresql/data --shm-size 256m \
+    -e "POSTGRES_HOST_AUTH_METHOD=trust" --name node2 -d kwildb/postgres:latest
+```
+
+:::tip
+Use `docker container ls` to check the `postgres` container status. When done testing
+`kwild`, use `docker container rm -f node0 node1 node2` and
+`docker volume rm kwil0-testnet-pgdata kwil1-testnet-pgdata kwil2-testnet-pgdata`
+to stop and delete them.
+:::
+
 To run the nodes, we can use the `kwild` binary in 3 separate terminals.  We will need to specify the `--root_dir` flag to
 point to the directory where the node config is located.
 
 ```bash title="Terminal 1"
-kwild --root-dir ./kwil-testnet/node0
+kwild --root-dir ./kwil-testnet/node0 --app.pg-db-port 5440
 ```
 
 ```bash title="Terminal 2"
-kwild --root-dir ./kwil-testnet/node1
+kwild --root-dir ./kwil-testnet/node1 --app.pg-db-port 5441
 ```
 
 ```bash title="Terminal 3"
-kwild --root-dir ./kwil-testnet/node2
+kwild --root-dir ./kwil-testnet/node2 --app.pg-db-port 5442
 ```
 
 Once the nodes are running, they will begin mining blocks.  You can now connect to their gRPC and HTTP
 endpoints to interact with your local network.
+
+## For Developers
+
+Given a clone of the source code repository and development tooling, there are
+other automated options for starting nodes for testing in the
+[README](https://github.com/kwilteam/kwil-db/blob/main/README.md). In
+particular, a Docker Compose service is defined in `deployments/compose/kwil`
+that automatically starts containers for both a single node with `--autogen` and
+a separate container for `postgres`. For a multi-node development environment,
+the command `task dev:testnet:up` will start several nodes in a network
+configuration.

--- a/docs/node/quickstart.mdx
+++ b/docs/node/quickstart.mdx
@@ -15,20 +15,21 @@ test `kwild`. To prepare a production deployment, see
 ## Installation
 
 To run either a single Kwil node, or a network of nodes, you will need to download the binaries.  Kwil releases
-binaries on [Github](<https://github.com/kwilteam/binary-releases/releases>).
+binaries on [Github](<https://github.com/kwilteam/kwil-db/releases>).
 
-Kwil also requires a dedicate PostgreSQL host configured for `kwild`.
+Kwil also requires a dedicated PostgreSQL host configured for `kwild`.
 
 See the [Installation](/docs/daemon/installation) page for details.
 
 ## Single Node
 
-First ensure that PostgreSQL is running and configured for `kwild`. See
-[Installation](/docs/daemon/installation) for details. For the quickstart, just:
+### Start
+
+First ensure that PostgreSQL is running and configured for `kwild`. For the quickstart, just:
 
 ```bash
 docker run -p 5432:5432 -v kwil-pgdata:/var/lib/postgresql/data --shm-size 256m \
-    -e "POSTGRES_HOST_AUTH_METHOD=trust" kwildb/postgres:latest
+   --name kwil-postgres -e "POSTGRES_HOST_AUTH_METHOD=trust" kwildb/postgres:latest
 ```
 
 To run a single node, simply use the `kwild` binary with the `--autogen` flag.
@@ -45,8 +46,19 @@ The node will be the one initial validator.
 As such, this mode is primarily useful for a quick deployment for evaluation and testing; production networks will define their own chain ID and initial validator set.
 :::
 
-To clean up when done testing, delete the `~/.kwild` folder and the
-`kwil-pgdata` Docker volume.
+### Cleanup
+
+To clean up when done testing, delete the `~/.kwild` folder, the postgres container, and the
+`kwil-pgdata` Docker volume:
+
+```shell
+# Remove kwild node data
+rm ~/.kwild -rf
+
+# Stop and remove the postgres container & volume
+docker container rm -f kwil-postgres
+docker volume rm kwil-pgdata
+```
 
 ## Multi-Node
 

--- a/docs/node/tutorial.mdx
+++ b/docs/node/tutorial.mdx
@@ -35,10 +35,17 @@ contains the configuration files, including `genesis.json` and `config.toml`.
 
 ### Running The Node
 
-Using the `kwild` binary, we can begin running the network with this single node:
+To run the first node, we will need to start a properly configured PostgreSQL instance. We will use a default pre-configured image provided by
+Kwil, but information on the proper configuration can be found in the [PostgreSQL configuration](/docs/daemon/installation#postgresql-configuration) section.
+Once the PostgreSQL instance is running, we can start the node using the `kwild` binary:
 
-```bash
-kwild --root-dir ./testnet/node0 --app.admin-listen-addr unix:///tmp/node0.sock
+```shell
+# Run Postgres
+docker run -d -p 5432:5432 --name kwil-postgres -e "POSTGRES_HOST_AUTH_METHOD=trust" \
+kwildb/postgres:latest
+
+# Run the node
+kwild --root-dir ./testnet/node0 --app.admin-listen-addr unix:///tmp/node0.sock --app.pg-db-port 5432
 ```
 
 The command then runs the local Kwil network, and begins producing blocks.
@@ -106,7 +113,12 @@ kwil-admin setup peer --root-dir ./testnet/node1 --genesis ./testnet/node0/genes
 Start the second node to verify that it was created correctly:
 
 ```bash
-kwild --root-dir=./testnet/node1
+# Run Postgres
+docker run -d -p 5431:5432 --name kwil-postgres-1 -e "POSTGRES_HOST_AUTH_METHOD=trust" \
+kwildb/postgres:latest
+
+# Run the node
+kwild --root-dir=./testnet/node1 --app.pg-db-port 5431
 ```
 
 If done correctly, you should be able to see the second node's logs, and it should be able to read the network logs.
@@ -159,6 +171,25 @@ $ kwil-admin validators list --rpcserver unix:///tmp/node0.sock
 Current validator set:
   0. {pubkey = 22cbbb666c26b2c1f42502df72c32de4d521138a1a2c96121d417a2f341a759c, power = 1}
   1. {pubkey = a2d8e307117695c8d0d3adbda136cb2ad630c43b8672a0eba46d79501831b794, power = 1}
+```
+
+## Cleanup
+
+If you wish to reset this tutorial, you will need to stop the nodes and Postgres containers, remove the `testnet` directory, and remove the Postgres container:
+
+```bash
+# Stop the nodes using Ctrl+C
+
+# Stop the Postgres containers
+docker stop kwil-postgres
+docker stop kwil-postgres-1
+
+# Remove the Postgres containers
+docker rm kwil-postgres
+docker rm kwil-postgres-1
+
+# Remove the testnet directory
+rm -rf ./testnet
 ```
 
 ## Conclusion

--- a/docs/node/tutorial.mdx
+++ b/docs/node/tutorial.mdx
@@ -15,12 +15,9 @@ In this tutorial, we will:
 4. Upgrade the second node to a validator.
 
 :::tip
-
-In order to do this tutorial, you will need to [install the `kwild` and
-`kwil-admin` binaries](<https://github.com/kwilteam/binary-releases/releases>),
+In order to do this tutorial, you will need to [install the `kwild` and `kwil-admin` binaries](<https://github.com/kwilteam/binary-releases/releases>),
 and ensure that a `postgres` instance is running and properly configured.
 See [postgresql installation](/docs/daemon/installation#postgresql) for setup instructions.
-
 :::
 
 ## Creating The First Node

--- a/docs/node/tutorial.mdx
+++ b/docs/node/tutorial.mdx
@@ -15,7 +15,12 @@ In this tutorial, we will:
 4. Upgrade the second node to a validator.
 
 :::tip
-In order to do this tutorial, you will need to [install the `kwild` and `kwil-admin` binaries](<https://github.com/kwilteam/binary-releases/releases>).
+
+In order to do this tutorial, you will need to [install the `kwild` and
+`kwil-admin` binaries](<https://github.com/kwilteam/binary-releases/releases>),
+and ensure that a `postgres` instance is running and properly configured.
+See .. for setup instructions.
+
 :::
 
 ## Creating The First Node
@@ -28,6 +33,9 @@ To create the node's configuration files, a new `genesis.json`, and a new keypai
 kwil-admin setup init -o ./testnet/node0
 ```
 
+The `./testnet/node0` folder will be the "root" directory for `kwild` that
+contains the configuration files, including `genesis.json` and `config.toml`.
+
 ### Running The Node
 
 Using the `kwild` binary, we can begin running the network with this single node:
@@ -37,6 +45,11 @@ kwild --root-dir ./testnet/node0 --app.admin-listen-addr unix:///tmp/node0.sock
 ```
 
 The command then runs the local Kwil network, and begins producing blocks.
+
+:::note
+We override the default `app.admin-listen-addr` since for the purposes
+of this tutorial we will run two nodes on the same machine.
+:::
 
 ### Getting The Node's Info
 
@@ -145,7 +158,7 @@ If the requesting node's public key is unknown, all pending requests and their p
 And that's it! The second node should now be a validator on the network.  To verify this, we can use the `kwil-admin` tool to get the list of validators:
 
 ```bash
-$ kwil-admin validators list-validators --rpcserver unix:///tmp/node0.sock
+$ kwil-admin validators list --rpcserver unix:///tmp/node0.sock
 Current validator set:
   0. {pubkey = 22cbbb666c26b2c1f42502df72c32de4d521138a1a2c96121d417a2f341a759c, power = 1}
   1. {pubkey = a2d8e307117695c8d0d3adbda136cb2ad630c43b8672a0eba46d79501831b794, power = 1}

--- a/docs/node/tutorial.mdx
+++ b/docs/node/tutorial.mdx
@@ -19,7 +19,7 @@ In this tutorial, we will:
 In order to do this tutorial, you will need to [install the `kwild` and
 `kwil-admin` binaries](<https://github.com/kwilteam/binary-releases/releases>),
 and ensure that a `postgres` instance is running and properly configured.
-See .. for setup instructions.
+See [postgresql installation](/docs/daemon/installation#postgresql) for setup instructions.
 
 :::
 


### PR DESCRIPTION
Mainly the Node Installation page.  I have a feeling this is TMI, but I wanted to be complete.  We could make a separate "Advanced PostgreSQL Setup" page for all the options, and just leave the one simple one (the one `postgres` Docker Compose) to the Installation page to keep it simple and not too intimidating.