### PR TITLE
fixed default docs

### DIFF
--- a/docs/node/daemon/config/settings.mdx
+++ b/docs/node/daemon/config/settings.mdx
@@ -27,7 +27,7 @@ This section provides a detailed overview of the operational parameters availabl
 
    - `admin_listen_addr`: This variable specifies the address where the daemon's admin gRPC server listens for connections. The default is `localhost:50151`.
 
-   - `pg_db_host`: PostgreSQL database host (UNIX socket path or IP address with no port). The default is `/var/run/postgresql`.
+   - `pg_db_host`: PostgreSQL database host (UNIX socket path or IP address with no port). The default is `localhost`.
 
    - `pg_db_port`: PostgreSQL database port (may be omitted for UNIX socket hosts). The default is `5432`.
 


### PR DESCRIPTION
I noticed that our docs had an incorrect default pg host.