### PR TITLE
document important Docker Daemon config

### DIFF
--- a/docs/node/daemon/eth-deposits.mdx
+++ b/docs/node/daemon/eth-deposits.mdx
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 5
-sidebar_label: "Eth Deposits"
+sidebar_label: "Ethereum Deposits"
 id: eth-deposits-oracle
-title: Eth Deposits Oracle
-description: Using the Eth Deposits Oracle
+title: Ethereum Deposits Oracle
+description: Using the Ethereum Deposits Oracle
 slug: /extensions/oracles/eth-deposits
 ---
 
@@ -20,7 +20,7 @@ Therefore this oracle can be used in a variety of use cases, such as:
 - Reward minters of NFTs with the Kwil gas as a part of the minting process.
 - Burn ERC20 tokens on Ethereum to acquire Kwil gas.
 
-Follow the steps below to use the Eth Deposits Oracle:
+Follow the steps below to use the Ethereum Deposits Oracle:
 1. [Implement the smart contract](#implement-smart-contract-with-credit-event) that emits the `Credit(address,uint256)` event.
 2. [Deploy the smart contract](#deploy-the-smart-contract) on an EVM chain.
 3. [Configure Kwil node](#configure-kwil-node) to start the `eth-deposits` oracle.
@@ -61,7 +61,7 @@ The next step is to configure the Kwil node to configure the `eth-deposits` orac
 1. `rpc_provider`: This variable specifies the WebSocket URL of the EVM node provider. This is a required field and would likely be an Infura or Alchemy URL.
 2. `contract_address`: This variable specifies the address of the deployed smart contract for the oracle to listen to the `Credit` events at. This is a required field.
 3. `starting_height`: This variable specifies the Ethereum block height at which the oracle starts to listen for the `Credit` events. Any events emitted before this block height are ignored. The default value is `0`.
-4. `required_confirmations`: This variable specifies the number of ethereum blocks that must be mined before the oracle creates a deposit event in Kwil. This is to protect against Ethereum network reorgs or soft forks. This is an optional field and defaults to `12` if not configured.
+4. `required_confirmations`: This variable specifies the number of Ethereum blocks that must be mined before the oracle creates a deposit event in Kwil. This is to protect against Ethereum network reorgs or soft forks. This is an optional field and defaults to `12` if not configured.
 5. `reconnection_interval`: This variable specifies the amount of time in seconds that the oracle will wait before reconnecting to the Ethereum RPC endpoint if it is disconnected. Long-running RPC subscriptions are prone to being reset by the Ethereum RPC endpoint, so this will allow the oracle to reconnect. This is an optional field and defaults to `60`s if not configured.
 6. `max_retries`: This variable specifies the number of times the oracle will attempt to reconnect to the Ethereum RPC endpoint before giving up. This is an optional field and defaults to `10` if not configured.
 7. `block_sync_chunk_size`: This variable specifies the number of Ethereum blocks requested by oracle from the Ethereum RPC endpoint at a time while catching up to the network. This is an optional field and defaults to `1000000` if not configured.

--- a/docs/node/daemon/kwild.mdx
+++ b/docs/node/daemon/kwild.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-sidebar_label: "Using Kwild"
+sidebar_label: "Using kwild"
 id: daemon-kwild
 title: Running a Kwil Node
 description: How to deploy a Kwil node using kwild

--- a/docs/node/daemon/postgres.mdx
+++ b/docs/node/daemon/postgres.mdx
@@ -122,6 +122,9 @@ sufficient free disk space and performance characteristics:
   "data-root": "/mnt/suitable_drive/docker"
 }
 ```
+
+If changing `"data-root"`, be sure to copy the previous Docker folder, which is
+typically `/var/lib/docker`.
 :::
 
 ### PostgreSQL Configuration

--- a/docs/node/daemon/postgres.mdx
+++ b/docs/node/daemon/postgres.mdx
@@ -97,11 +97,32 @@ This means that it will fail to start if there is a process on the host machine
 already listening on port 5432.
 :::
 
-A persistent Docker volume called `postgres_kwildb` will be created. If
-resetting `kwild`'s data folders, it is also necessary to delete this volume.
-Ensure that the Docker Engine is running and configured so that the `postgres`
-service has sufficient disk, CPU, and memory resources for demand of your
-application.
+If resetting `kwild`'s data folders, it is also necessary to delete the
+`kwil-pgdata` Docker volume, or whatever named volume was used in the `docker run`
+command. Ensure that the Docker Daemon is running and configured so that
+the `postgres` service has sufficient disk, CPU, and memory resources for demand
+of your application.
+
+:::tip
+If using Docker Daemon directly rather than Docker Desktop, such as would be the
+case on a headless server, it is recommended to modify the Docker configuration
+to disable the "userland proxy" for performance reasons.
+
+Also, if the system disk partition has limited free space or uses a slow block
+device, as is common on certain cloud providers, either change the `"data-root"`
+Docker setting or use a suitable host file system path rather than a named volume.
+
+Modify the docker configuration as follows, setting `"userland-proxy"` to
+`false`, and `"data-root"` to the location of a directory on a file system with
+sufficient free disk space and performance characteristics:
+
+```json title="/etc/docker/daemon.json"
+{
+  "userland-proxy": false,
+  "data-root": "/mnt/suitable_drive/docker"
+}
+```
+:::
 
 ### PostgreSQL Configuration
 
@@ -175,4 +196,4 @@ the official [PostgreSQL documentation](https://www.postgresql.org/docs/16/auth-
 
 ## Running `kwild`
 
-Continue to the [Using Kwild](/docs/daemon/kwild) page for running Kwil node.
+Continue to the [Using `kwild`](/docs/daemon/kwild) page for running Kwil node.


### PR DESCRIPTION
This adds a "tip" section to the PostgreSQL docker section.

When running Docker Daemon on a server (not Docker Desktop), there is a "userland proxy" that runs by default to proxy network traffic between host and container.  This is [known](https://franckpachot.medium.com/high-cpu-usage-in-docker-proxy-with-chatty-database-application-disable-userland-proxy-415ffa064955) to have an very high CPU cost, and I always disable it.  In @charithabandi 's tests, it could be observed eating as much CPU as postgres itself.

This also changes some unrelated formatting:
 - "Eth" -> "Ethereum".  In general, it should be ETH for the ticker on the unit of value, or Ethereum for the network or more broad discussions.  I picked Ethereum, but let me know if ETH is right in some contexts.
 - "Kwild" -> "kwild", with code formatting as allowed by Docusaurus