### PR TITLE
fix: incorrect extension flag

### DIFF
--- a/docs/node/daemon/config/settings.mdx
+++ b/docs/node/daemon/config/settings.mdx
@@ -495,6 +495,6 @@ The one exception to the above is for configuring values in the `app.extensions`
 Extension configs must be specified after all others, and must be delimited from the rest of the command line arguments by a double dash `--`:
 
 ```bash
-kwild --autogen --app.private_key_path ./private_key -- --app.extension.<extension-name>.<config-key> <config-value>
+kwild --autogen --app.private_key_path ./private_key -- --extension.<extension-name>.<config-key> <config-value>
 ```
 :::


### PR DESCRIPTION
I noticed a typo in the extension flag docs for `kwild`