### PR TITLE
fix: sql syntax diagram rule not clickable

### DIFF
--- a/docs/kuneiform/sql-as-understood-by-kwil/syntax-diagrams.md
+++ b/docs/kuneiform/sql-as-understood-by-kwil/syntax-diagrams.md
@@ -12,7 +12,7 @@ slug: /syntax-diagrams
 
 <iframe
   id="diagram-iframe"
-  src="https://htmlpreview.github.io/?https://raw.githubusercontent.com/kwilteam/kwil-db/release-v0.8/parse/grammar/rrdiagrams.html"
+  src="https://kwilteam.github.io/kwil-db/parse/grammar/rrdiagrams.html"
   position="absolute"
   style={{
     border: "none",


### PR DESCRIPTION
The issue: If you go https://docs.kwil.com/docs/syntax-diagrams/ and click any rule block, you'll see error, because the HTML doesn't work properly.

This changes the embedded SQL syntax diagram to kwil-db Github Page, so the html anchor works.

Note: This is a better yet not ideal solution, since we can only serve one version of the syntax.

----

To support multi versions of SQL syntax diagram, we have 2 options:

First approach is, an extra Github Action that:
- will be triggered on release branch update:
- re-generate diagram html file
- put the diagram in different folder named in version, in `docs/sql-syntax` folder
- push the changes to `main` branch

So we can have a URL point to one version, for example: https://kwilteam.github.io/kwil-db/docs/sql-syntax/v0.8/index.html

The second approach is, still, an extra Github Action that:
- will be triggered on release branch update:
- re-generate diagram html file
- replace all `#XXX` anchors in html file to https://htmlpreview.github.io/?https://raw.githubusercontent.com/kwilteam/kwil-db/release-v0.8/parse/grammar/rrdiagrams.html#XXX

And we can serve different versions of diagrams at different release branches.