### PR TITLE
updated operator precedence

### DIFF
--- a/docs/kuneiform/sql-as-understood-by-kwil/operators.mdx
+++ b/docs/kuneiform/sql-as-understood-by-kwil/operators.mdx
@@ -7,25 +7,23 @@ description: "Order of precedence for operators in Kuneiform."
 slug: /kuneiform/operators
 ---
 
-The below table shows order of operations for all operators, from highest to lowest precedence. This generally matches
-[Postgres's operator precedence](<https://www.postgresql.org/docs/7.2/sql-precedence.html>), albeit with a restricted
-set of operators.
+The below table shows order of operations for all operators, from highest to lowest precedence.
 
 | Operator | Associativity | Description |
 | -------- | ------------- | ----------- |
 | `()` | | Parentheses |
-| `::` | Left | Type Cast |
-| `[]` | Left | Array Index |
 | `.` | Left | Member Access |
+| `[]` | Left | Array Index |
 | `-` | Right | Negation |
+| `COLLATE` | Left | Collation |
 | `*`, `/`, `%` | Left | Multiplication, Division, Modulo |
 | `+`, `-` | Left | Addition, Subtraction |
-| `IS` |  | Type Comparison |
+| any other expression | Left | any other expression |
 | `IN` |  | Set Membership |
-| `BETWEEN` |  | Range Comparison |
 | `LIKE`, `ILIKE` |  | Pattern Matching |
-| `>`, `<`, `>=`, `<=` |  | Comparison |
-| `==`, `!=`, `=`, `:=` | Right | Equal, Not Equal, SQL Assignment, Procedure Assignment |
+| `BETWEEN` |  | Range Comparison |
+| `==`, `!=`, `=`, `>`, `<`, `>=`, `<=` |  | Comparison |
+| `IS` |  | Type Comparison |
 | `NOT` | Right | Logical NOT |
 | `AND` | Left | Logical AND |
 | `OR` | Left | Logical OR |


### PR DESCRIPTION
This PR updates our operator precedence table. It is loosely based on the https://github.com/kwilteam/docs/issues/133 issue, but I decided to not add an extra column as noted in the issue, because I felt it looked weird and was more confusing than helpful.

Resolves https://github.com/kwilteam/docs/issues/133