### PR TITLE
statesync: reorg and doc psql/pg_dump req

### DIFF
--- a/docs/node/daemon/postgres.mdx
+++ b/docs/node/daemon/postgres.mdx
@@ -19,8 +19,11 @@ start a new container:
 
 ```bash
 docker run -p 5432:5432 --name kwil-postgres -e "POSTGRES_HOST_AUTH_METHOD=trust" \
-    kwildb/postgres:latest
+    --shm-size 256m kwildb/postgres:latest
 ```
+
+Be sure to disable any OS unattended upgrades to prevent `"docker"`, `"containerd"`, and
+`"postgresql"` packages from being updated while the node is running.
 
 ### PostgreSQL Installation
 

--- a/docs/node/statesync.mdx
+++ b/docs/node/statesync.mdx
@@ -1,32 +1,25 @@
 ---
 sidebar_position: 5
-sidebar_label: "Statesync"
+sidebar_label: "State Sync"
 id: "Statesync"
 title: "Using State Sync"
-description: "Learn how to bootstrap a new node using statesync"
+description: "Learn how to bootstrap a new node using state sync"
 slug: /node/statesync
 ---
 
-Any new node joining a network needs to first catch up with the existing nodes. The default approach is to replay all the blocks from the genesis. Depending on the number of blocks in the chain, this process can take a long time.
+Any new node joining a network needs to first catch up with the existing nodes. The default approach is to replay all the blocks from genesis. Depending on the number of blocks in the chain, this process can take a long time.
 
-Statesync is a feature that allows a new node to bootstrap directly from a snapshot instead of replaying all the blocks from the genesis. Statesync greatly reduces the time needed to sync a new node to a network; however, the node will have a truncated history starting from the height of the snapshot.
+State sync is a feature that allows a new node to bootstrap directly from a state snapshot instead of replaying all the blocks from genesis. State sync greatly reduces the time needed to sync a new node to a network; however, the node will have a truncated transaction history starting from the height of the snapshot.
 
-:::note
-Statesync should not be used on a partially synced node. If you have a partially synced node, it switches to blocksync to sync the remaining blocks.
+:::info
+Snapshot creation requires the `pg_dump` tool on the node, while snapshot restoration requires `psql`.
+These are typically included in a `postgresql-client` package. They must be the same version
+as the PostgreSQL daemon (`postgres`) that is required by a particular version of Kwil DB.
 :::
 
-## Trusted Snapshot Providers
+## Snapshot Creation
 
-To support statesync, each network should have at least one trusted snapshot provider responsible for creating, distributing, and validating snapshots. 
-
-### Setting up Trusted Snapshot Providers
-
-Trusted snapshot providers are regular full nodes with [snapshot creation](/docs/daemon/config/settings#appsnapshots) enabled. A trusted snapshot provider must have both P2P and RPC services accessible to other nodes. The P2P service allows the snapshots that the node creates to be distributed. The RPC service is used by joining nodes to validate snapshots received from either the trusted provider or other nodes.
-
-Along with the trusted snapshot providers, other nodes in the network can also enable snapshots and distribute them to the joining nodes during the statesync process. However, a joining node only accepts these snapshots after validating them with the trusted snapshot providers.
-
-### Enabling Snapshot Creation
-Snapshots can be enabled on the Kwil nodes by providing the following configuration in the `config.toml` file. Refer to the [snapshot](/docs/daemon/config/settings#appsnapshots) configuration for more details.
+Kwil nodes may be configured to create and share snapshots with the following configuration in the `config.toml` file. Refer to the [snapshot](/docs/daemon/config/settings#appsnapshots) configuration for more details.
 
 ```toml
 [app.snapshots]
@@ -48,9 +41,15 @@ If snapshots are enabled, node generates snapshots at every block height that is
 
 For example, a node with the above configuration will generate snapshots at every 10,000 block height. If the node currently has snapshots at height 10000, 20000, and 30000, the node will generate the next snapshot at height 40000. As the max_snapshots is set to 3, the snapshot at height 10000 will be deleted when the snapshot at height 40000 is created.
 
-## Configuring Statesync
+# State Sync
 
-Configure the new node to use statesync by providing the following configuration in the `config.toml` file.
+If there are existing nodes on a network creating snapshots, a new node may use state sync to bootstrap their node from these snapshots
+
+:::info
+State sync is only used for node bootstrapping. Catch-up after a restart will use block sync.
+:::
+
+Configure the new node to use state sync by providing the following configuration in the `config.toml` file.
 
 ```yaml
 [chain.statesync]
@@ -66,7 +65,7 @@ snapshot_dir = "rcvd_snaps"
 
 # Trusted snapshot providers (comma-separated chain RPC servers) are the source-of-truth for the snapshot integrity.
 # Snapshots are accepted for statesync only after verifying it with these trusted snapshot providers.
-# Atleast 1 trusted rpc server is required for enabling state sync.
+# At least 1 trusted rpc server is required for enabling state sync.
 rpc_servers = "http://rpc1:26657,http://rpc2:26657"
 
 # Time to spend discovering snapshots before initiating a restore. (default: 15 seconds)
@@ -80,8 +79,17 @@ chunk_request_timeout = "10s"
 # the state sync process is aborted and the node will fall back to the regular block sync process.
 ```
 
-When state sync is enabled, the node first discovers snapshots from all its connected peers. It then selects the latest snapshot from those discovered and validates the integrity of the snapshot with the trusted snapshot provider. Once a valid snapshot is identified, the node fetches the snapshot chunks from the peers and restores the database state using these chunks. The node then begins syncing blocks starting from the snapshot height.
+When state sync is enabled, the node first discovers snapshots from its peers. It then selects the latest snapshot from those discovered and validates the integrity of the snapshot with the trusted snapshot RPC provider. Once a valid snapshot is identified, the node fetches the snapshot from its peers and restores the application state from the snapshot. After state restoration, the node then begins syncing blocks starting from the snapshot height.
 
 :::note
-The node will stay in the discovery phase until a snapshot is discovered and validated. If there are no snapshots in the network, the node will be stuck in the discovery phase. To make progess, disable statesync and restart the node. The node will then progress with blocksync.
+The node will stay in the discovery phase until a snapshot is discovered and validated. If there are no snapshots in the network, the node will be stuck in the discovery phase. To make progress, disable statesync and restart the node. The node will then progress with blocksync.
 :::
+
+### Trusted Snapshot Providers
+
+A network should have at least one trusted snapshot provider responsible for verifying snapshot integrity.
+
+Trusted snapshot providers are regular full nodes with [snapshot creation](/docs/daemon/config/settings#appsnapshots) enabled, and which provide snapshot checksums on their RPC service.
+The RPC service is used by joining nodes to validate snapshots received via P2P communication from either the trusted provider or other nodes.
+
+Along with the trusted snapshot providers, other nodes in the network can also enable snapshots and distribute them to the joining nodes during the statesync process. However, a joining node only accepts these snapshots after validating them with the trusted snapshot providers.

--- a/docs/node/statesync.mdx
+++ b/docs/node/statesync.mdx
@@ -43,7 +43,7 @@ For example, a node with the above configuration will generate snapshots at ever
 
 # State Sync
 
-If there are existing nodes on a network creating snapshots, a new node may use state sync to bootstrap their node from these snapshots
+If there are existing nodes on a network creating snapshots, a new node may use state sync to bootstrap their node from these snapshots.
 
 :::info
 State sync is only used for node bootstrapping. Catch-up after a restart will use block sync.


### PR DESCRIPTION
This revises the statesync docs page:
- note about requiring the `psql` and `pg_dump` tools
- reorganize sections
- statesync -> state sync (as per cometbft plain-language docs rather than code)
- reword trusted providers desc