### PR TITLE
rename kwil-admin peers to kwil-admin whitelist

### DIFF
--- a/docs/node/admin/kwil-admin/index.md
+++ b/docs/node/admin/kwil-admin/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 99
 sidebar_label: "Reference"
 id: "kwil-admin"
 title: "kwil-admin"
@@ -26,11 +26,12 @@ The Kwil node admin tool.
 ### SEE ALSO
 
 * [kwil-admin key](/docs/ref/kwil-admin/key)	 - The `key` command provides subcommands for private key generation and inspection.
+* [kwil-admin migrate](/docs/ref/kwil-admin/migrate)	 - The `migrate` command provides functions for managing migration proposals.
 * [kwil-admin node](/docs/ref/kwil-admin/node)	 - The `node` command is used to get information about a running Kwil node.
-* [kwil-admin peers](/docs/ref/kwil-admin/peers)	 - manages the node's peers
 * [kwil-admin setup](/docs/ref/kwil-admin/setup)	 - The `setup` command provides functions for creating and managing node configuration and data.
 * [kwil-admin snapshot](/docs/ref/kwil-admin/snapshot)	 - The `snapshot` command is used to create and manage snapshots.
 * [kwil-admin utils](/docs/ref/kwil-admin/utils)	 - The `utils` command is used to get information about a running Kwil node.
 * [kwil-admin validators](/docs/ref/kwil-admin/validators)	 - The `validators` command provides functions for creating and broadcasting validator-related transactions.
 * [kwil-admin version](/docs/ref/kwil-admin/version)	 - Displays the cli version information.
+* [kwil-admin whitelist](/docs/ref/kwil-admin/whitelist)	 - The whitelist command is used to manage a node's peer whitelist.
 

--- a/docs/node/admin/kwil-admin/key/index.md
+++ b/docs/node/admin/kwil-admin/key/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 99
 sidebar_label: "key"
 id: "kwil-admin-key"
 title: "kwil-admin key"

--- a/docs/node/admin/kwil-admin/migrate/approve.mdx
+++ b/docs/node/admin/kwil-admin/migrate/approve.mdx
@@ -1,0 +1,45 @@
+---
+sidebar_position: 1
+sidebar_label: "approve"
+id: "kwil-admin-migrate-approve"
+title: "kwil-admin migrate approve"
+description: "Approve a migration proposal."
+slug: /ref/kwil-admin/migrate/approve
+---
+
+## kwil-admin migrate approve
+
+Approve a migration proposal.
+
+```
+kwil-admin migrate approve <proposal-id> [flags]
+```
+
+### Examples
+
+```
+kwil-admin migrate approve <proposal-id>
+```
+
+### Options
+
+```
+  -h, --help   help for approve
+```
+
+### Options inherited from parent commands
+
+```
+      --authrpc-cert string   kwild's TLS certificate, required for HTTPS server
+      --output string         the format for command output - either 'text' or 'json' (default "text")
+      --pass string           admin server password (alternative to mTLS with tlskey/tlscert). May be set in ~/.kwil-admin/rpc-admin-pass instead.
+  -s, --rpcserver string      admin RPC server address (either unix or tcp) (default "/tmp/kwild.socket")
+  -S, --silence               Silence logs
+      --tlscert string        kwil-admin's TLS certificate file for server to authenticate us (default "auth.cert")
+      --tlskey string         kwil-admin's TLS key file to establish a mTLS (authenticated) connection (default "auth.key")
+```
+
+### SEE ALSO
+
+* [kwil-admin migrate](/docs/ref/kwil-admin/migrate)	 - The `migrate` command provides functions for managing migration proposals.
+

--- a/docs/node/admin/kwil-admin/migrate/genesis-state.mdx
+++ b/docs/node/admin/kwil-admin/migrate/genesis-state.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 2
+sidebar_label: "genesis-state"
+id: "kwil-admin-migrate-genesis-state"
+title: "kwil-admin migrate genesis-state"
+description: "Download the genesis state corresponding to the ongoing migration."
+slug: /ref/kwil-admin/migrate/genesis-state
+---
+
+## kwil-admin migrate genesis-state
+
+Download the genesis state corresponding to the ongoing migration.
+
+### Synopsis
+
+Download the genesis state for the new network from a trusted node on the source network. The genesis state includes the genesis config file (genesis.json), genesis snapshot (snapshot.sql.gz), and the migration info such as the start and end heights. The genesis state is saved in the root directory specified by the `--root-dir` flag. If there is no approved migration or if the migration has not started yet, the command will return a message indicating that there is no genesis state to download.
+
+```
+kwil-admin migrate genesis-state [flags]
+```
+
+### Examples
+
+```
+# Download the genesis state to the default root directory (~/.kwild)
+kwil-admin migrate genesis-state
+
+# Download the genesis state to a custom root directory
+kwil-admin migrate genesis-state --root-dir /path/to/root/dir
+```
+
+### Options
+
+```
+      --authrpc-cert string   kwild's TLS certificate, required for HTTPS server
+  -h, --help                  help for genesis-state
+      --pass string           admin server password (alternative to mTLS with tlskey/tlscert). May be set in ~/.kwil-admin/rpc-admin-pass instead.
+  -r, --root-dir string       Root directory for the genesis state files (default "~/.kwild")
+  -s, --rpcserver string      admin RPC server address (either unix or tcp) (default "/tmp/kwild.socket")
+      --tlscert string        kwil-admin's TLS certificate file for server to authenticate us (default "auth.cert")
+      --tlskey string         kwil-admin's TLS key file to establish a mTLS (authenticated) connection (default "auth.key")
+```
+
+### Options inherited from parent commands
+
+```
+      --output string   the format for command output - either 'text' or 'json' (default "text")
+  -S, --silence         Silence logs
+```
+
+### SEE ALSO
+
+* [kwil-admin migrate](/docs/ref/kwil-admin/migrate)	 - The `migrate` command provides functions for managing migration proposals.
+

--- a/docs/node/admin/kwil-admin/migrate/index.md
+++ b/docs/node/admin/kwil-admin/migrate/index.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 99
+sidebar_label: "migrate"
+id: "kwil-admin-migrate"
+title: "kwil-admin migrate"
+description: "The `migrate` command provides functions for managing migration proposals."
+slug: /ref/kwil-admin/migrate
+---
+
+## kwil-admin migrate
+
+The `migrate` command provides functions for managing migration proposals.
+
+### Synopsis
+
+The `migrate` command provides functions for managing migration proposals.
+
+### Options
+
+```
+      --authrpc-cert string   kwild's TLS certificate, required for HTTPS server
+  -h, --help                  help for migrate
+      --pass string           admin server password (alternative to mTLS with tlskey/tlscert). May be set in ~/.kwil-admin/rpc-admin-pass instead.
+  -s, --rpcserver string      admin RPC server address (either unix or tcp) (default "/tmp/kwild.socket")
+      --tlscert string        kwil-admin's TLS certificate file for server to authenticate us (default "auth.cert")
+      --tlskey string         kwil-admin's TLS key file to establish a mTLS (authenticated) connection (default "auth.key")
+```
+
+### Options inherited from parent commands
+
+```
+      --output string   the format for command output - either 'text' or 'json' (default "text")
+  -S, --silence         Silence logs
+```
+
+### SEE ALSO
+
+* [kwil-admin](/docs/ref/kwil-admin)	 - The Kwil node admin tool.
+* [kwil-admin migrate approve](/docs/ref/kwil-admin/migrate/approve)	 - Approve a migration proposal.
+* [kwil-admin migrate genesis-state](/docs/ref/kwil-admin/migrate/genesis-state)	 - Download the genesis state corresponding to the ongoing migration.
+* [kwil-admin migrate list](/docs/ref/kwil-admin/migrate/list)	 - List all the pending migration proposals.
+* [kwil-admin migrate propose](/docs/ref/kwil-admin/migrate/propose)	 - Submit a migration proposal.
+* [kwil-admin migrate status](/docs/ref/kwil-admin/migrate/status)	 - Get the status of the pending migration proposal.
+

--- a/docs/node/admin/kwil-admin/migrate/list.mdx
+++ b/docs/node/admin/kwil-admin/migrate/list.mdx
@@ -1,0 +1,50 @@
+---
+sidebar_position: 3
+sidebar_label: "list"
+id: "kwil-admin-migrate-list"
+title: "kwil-admin migrate list"
+description: "List all the pending migration proposals."
+slug: /ref/kwil-admin/migrate/list
+---
+
+## kwil-admin migrate list
+
+List all the pending migration proposals.
+
+### Synopsis
+
+List all the pending migration proposals.
+
+```
+kwil-admin migrate list [flags]
+```
+
+### Examples
+
+```
+# List all the pending migration proposals.
+kwil-admin migrate list
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --authrpc-cert string   kwild's TLS certificate, required for HTTPS server
+      --output string         the format for command output - either 'text' or 'json' (default "text")
+      --pass string           admin server password (alternative to mTLS with tlskey/tlscert). May be set in ~/.kwil-admin/rpc-admin-pass instead.
+  -s, --rpcserver string      admin RPC server address (either unix or tcp) (default "/tmp/kwild.socket")
+  -S, --silence               Silence logs
+      --tlscert string        kwil-admin's TLS certificate file for server to authenticate us (default "auth.cert")
+      --tlskey string         kwil-admin's TLS key file to establish a mTLS (authenticated) connection (default "auth.key")
+```
+
+### SEE ALSO
+
+* [kwil-admin migrate](/docs/ref/kwil-admin/migrate)	 - The `migrate` command provides functions for managing migration proposals.
+

--- a/docs/node/admin/kwil-admin/migrate/propose.mdx
+++ b/docs/node/admin/kwil-admin/migrate/propose.mdx
@@ -1,0 +1,55 @@
+---
+sidebar_position: 4
+sidebar_label: "propose"
+id: "kwil-admin-migrate-propose"
+title: "kwil-admin migrate propose"
+description: "Submit a migration proposal."
+slug: /ref/kwil-admin/migrate/propose
+---
+
+## kwil-admin migrate propose
+
+Submit a migration proposal.
+
+### Synopsis
+
+A Validator operator can submit a migration proposal using the `propose` subcommand. The migration proposal includes the new `chain-id`, `activation-period` and `duration`. This action will generate a migration resolution for the other validators to vote on. If a super-majority of validators approve the migration proposal, the migration will commence after the specified activation-period blocks from approval and will continue for the duration defined by duration blocks.
+
+```
+kwil-admin migrate propose [flags]
+```
+
+### Examples
+
+```
+# Submit a migration proposal to migrate to a new chain "kwil-chain-new" with activation period 1000 and migration duration of 14400 blocks.
+kwil-admin migrate propose --activation-period 1000 --duration 14400 --chain-id kwil-chain-new
+(or)
+kwil-admin migrate propose -a 1000 -d 14400 -c kwil-chain-new
+```
+
+### Options
+
+```
+  -a, --activation-period uint   The number of blocks before the migration is activated since the approval of the proposal.
+  -c, --chain-id string          The chain ID of the migration.
+  -d, --duration uint            The duration of the migration.
+  -h, --help                     help for propose
+```
+
+### Options inherited from parent commands
+
+```
+      --authrpc-cert string   kwild's TLS certificate, required for HTTPS server
+      --output string         the format for command output - either 'text' or 'json' (default "text")
+      --pass string           admin server password (alternative to mTLS with tlskey/tlscert). May be set in ~/.kwil-admin/rpc-admin-pass instead.
+  -s, --rpcserver string      admin RPC server address (either unix or tcp) (default "/tmp/kwild.socket")
+  -S, --silence               Silence logs
+      --tlscert string        kwil-admin's TLS certificate file for server to authenticate us (default "auth.cert")
+      --tlskey string         kwil-admin's TLS key file to establish a mTLS (authenticated) connection (default "auth.key")
+```
+
+### SEE ALSO
+
+* [kwil-admin migrate](/docs/ref/kwil-admin/migrate)	 - The `migrate` command provides functions for managing migration proposals.
+

--- a/docs/node/admin/kwil-admin/migrate/status.mdx
+++ b/docs/node/admin/kwil-admin/migrate/status.mdx
@@ -1,0 +1,50 @@
+---
+sidebar_position: 5
+sidebar_label: "status"
+id: "kwil-admin-migrate-status"
+title: "kwil-admin migrate status"
+description: "Get the status of the pending migration proposal."
+slug: /ref/kwil-admin/migrate/status
+---
+
+## kwil-admin migrate status
+
+Get the status of the pending migration proposal.
+
+### Synopsis
+
+Get the status of the pending migration proposal.
+
+```
+kwil-admin migrate status [flags]
+```
+
+### Examples
+
+```
+# Get the status of the pending migration.
+kwil-admin migrate status <proposalID>
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --authrpc-cert string   kwild's TLS certificate, required for HTTPS server
+      --output string         the format for command output - either 'text' or 'json' (default "text")
+      --pass string           admin server password (alternative to mTLS with tlskey/tlscert). May be set in ~/.kwil-admin/rpc-admin-pass instead.
+  -s, --rpcserver string      admin RPC server address (either unix or tcp) (default "/tmp/kwild.socket")
+  -S, --silence               Silence logs
+      --tlscert string        kwil-admin's TLS certificate file for server to authenticate us (default "auth.cert")
+      --tlskey string         kwil-admin's TLS key file to establish a mTLS (authenticated) connection (default "auth.key")
+```
+
+### SEE ALSO
+
+* [kwil-admin migrate](/docs/ref/kwil-admin/migrate)	 - The `migrate` command provides functions for managing migration proposals.
+

--- a/docs/node/admin/kwil-admin/node/index.md
+++ b/docs/node/admin/kwil-admin/node/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 99
 sidebar_label: "node"
 id: "kwil-admin-node"
 title: "kwil-admin node"

--- a/docs/node/admin/kwil-admin/peers/index.md
+++ b/docs/node/admin/kwil-admin/peers/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 99
 sidebar_label: "peers"
 id: "kwil-admin-peers"
 title: "kwil-admin peers"

--- a/docs/node/admin/kwil-admin/peers/list.mdx
+++ b/docs/node/admin/kwil-admin/peers/list.mdx
@@ -18,7 +18,7 @@ kwil-admin peers list [flags]
 ### Examples
 
 ```
-kwil-admin peers list --rpcserver /tmp/kwild.socket
+kwil-admin peers list
 ```
 
 ### Options

--- a/docs/node/admin/kwil-admin/peers/remove.mdx
+++ b/docs/node/admin/kwil-admin/peers/remove.mdx
@@ -18,7 +18,7 @@ kwil-admin peers remove <peerID> [flags]
 ### Examples
 
 ```
-kwil-admin peers remove 6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0 --rpcserver /tmp/kwild.socket
+kwil-admin peers remove <peerID>
 ```
 
 ### Options

--- a/docs/node/admin/kwil-admin/setup/genesis-hash.mdx
+++ b/docs/node/admin/kwil-admin/setup/genesis-hash.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 1
+sidebar_label: "genesis-hash"
+id: "kwil-admin-setup-genesis-hash"
+title: "kwil-admin setup genesis-hash"
+description: "Compute genesis hash from existing PostgreSQL datasets, and optionally update `genesis.json`."
+slug: /ref/kwil-admin/setup/genesis-hash
+---
+
+## kwil-admin setup genesis-hash
+
+Compute genesis hash from existing PostgreSQL datasets, and optionally update `genesis.json`.
+
+### Synopsis
+
+Compute the genesis hash from existing PostgreSQL datasets, and optionally update a `genesis.json` file.
+It can be configured to connect to Postgres either using the root directory (from which the `config.toml` will be read),
+or by specifying the connection details directly.
+
+Alternatively, a snapshot file can be provided to compute the genesis hash from a snapshot file instead of the database. The snapshot can either be
+a .sql or .sql.gz file.
+
+By default, it will print the genesis hash to stdout. To specify a genesis file to update as well, use the `--genesis` flag.
+
+```
+kwil-admin setup genesis-hash [flags]
+```
+
+### Examples
+
+```
+# Compute the genesis hash from an existing PostgreSQL database using a connection, and add it to a genesis file
+kwil-admin setup genesis-hash --dbname kwild --host "127.0.0.1" --port "5432" --user kwild --genesis "~/.kwild/abci/config/genesis.json"
+
+# Compute the genesis hash from an existing PostgreSQL database using the root directory
+kwil-admin setup genesis-hash --genesis "~/.kwild/abci/config/genesis.json" --root-dir "~/.kwild"
+
+# Compute the genesis hash from a snapshot file
+kwil-admin setup genesis-hash --snapshot "/path/to/snapshot.sql.gz" --genesis "~/.kwild/abci/config/genesis.json"
+```
+
+### Options
+
+```
+      --dbname string     Name of the database in the PostgreSQL server (default "kwild")
+  -g, --genesis string    optional path to the genesis file to patch with the computed app hash
+  -h, --help              help for genesis-hash
+      --host string       Host of the database (default "localhost")
+      --password string   Password for the database user
+      --port string       Port of the database (default "5432")
+  -r, --root-dir string   optional path to the root directory of the kwild node from which the genesis hash will be computed
+  -s, --snapshot string   optional path to the snapshot file to use for the genesis hash computation
+      --user string       User with administrative privileges on the database (default "postgres")
+```
+
+### Options inherited from parent commands
+
+```
+      --output string   the format for command output - either 'text' or 'json' (default "text")
+  -S, --silence         Silence logs
+```
+
+### SEE ALSO
+
+* [kwil-admin setup](/docs/ref/kwil-admin/setup)	 - The `setup` command provides functions for creating and managing node configuration and data.
+

--- a/docs/node/admin/kwil-admin/setup/index.md
+++ b/docs/node/admin/kwil-admin/setup/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 99
 sidebar_label: "setup"
 id: "kwil-admin-setup"
 title: "kwil-admin setup"
@@ -33,9 +33,9 @@ The `setup` command provides functions for creating and managing node configurat
 ### SEE ALSO
 
 * [kwil-admin](/docs/ref/kwil-admin)	 - The Kwil node admin tool.
+* [kwil-admin setup genesis-hash](/docs/ref/kwil-admin/setup/genesis-hash)	 - Compute genesis hash from existing PostgreSQL datasets, and optionally update `genesis.json`.
 * [kwil-admin setup init](/docs/ref/kwil-admin/setup/init)	 - The `init` command facilitates quick setup of an isolated Kwil node.
-* [kwil-admin setup peer](/docs/ref/kwil-admin/setup/peer)	 - The `peer` command facilitates quick setup of a Kwil node as a peer to an existing node.
 * [kwil-admin setup reset](/docs/ref/kwil-admin/setup/reset)	 - To delete all of a Kwil node's data files, use the `reset` command.
-* [kwil-admin setup reset-state](/docs/ref/kwil-admin/setup/reset-state)	 - Delete blockchain state files.
+* [kwil-admin setup reset-state](/docs/ref/kwil-admin/setup/reset-state)	 - `reset-state` deletes the data in Postgres.
 * [kwil-admin setup testnet](/docs/ref/kwil-admin/setup/testnet)	 - The `testnet` command is used to create multiple node configurations, all with the same genesis config, and pre-configured to connect to each other.
 

--- a/docs/node/admin/kwil-admin/setup/init.mdx
+++ b/docs/node/admin/kwil-admin/setup/init.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 sidebar_label: "init"
 id: "kwil-admin-setup-init"
 title: "kwil-admin setup init"
@@ -31,13 +31,82 @@ kwil-admin setup init -o ~/.kwild-new
 ### Options
 
 ```
-      --alloc allocFlag           account=amount pairs of genesis account allocations (default map[])
-  -i, --block-interval duration   shortest block interval in seconds (default 6s)
-      --chain-id string           chain ID to use for the genesis file
-      --gas                       enable gas
-  -h, --help                      help for init
-      --join-expiry int           number of blocks before a join request expires (default 14400)
-  -o, --output-dir string         generated node parent directory (default "./.testnet")
+      --alloc allocFlag                                  account=amount pairs of genesis account allocations (default map[])
+      --app.admin-listen-addr string                     kwild admin listen address (unix or tcp) (default "/tmp/kwild.socket")
+      --app.admin-notls                                  do not enable TLS on admin server (automatically disabled for unix socket or loopback listen addresses)
+      --app.admin-pass string                            password for the node's admin service (may be empty)
+      --app.challenge-expiry duration                    Time after which a challenge expires (default 10s)
+      --app.challenge-rate-limit float                   challenge request rate limit per second per client IP (default 10)
+      --app.db-read-timeout duration                     timeout for database reads initiated by RPC requests (default 5s)
+      --app.extension-endpoints strings                  kwild extension endpoints
+      --app.genesis-state string                         Path to the genesis state file
+      --app.hostname string                              kwild Server hostname
+      --app.jsonrpc-listen-addr string                   kwild JSON-RPC listen address (default "0.0.0.0:8484")
+      --app.migrate-from string                          kwild JSON-RPC listening address of the node to replicate the state from.
+      --app.pg-db-host string                            PostgreSQL host address (no port) (default "127.0.0.1")
+      --app.pg-db-name string                            PostgreSQL database name (default "kwild")
+      --app.pg-db-pass string                            PostgreSQL password name
+      --app.pg-db-port string                            PostgreSQL port (default "5432")
+      --app.pg-db-user string                            PostgreSQL user name (default "kwild")
+      --app.private-key-path string                      Path to the node private key file (default "private_key")
+      --app.private-rpc                                  Enforce data privacy with authenticated call request, disabled ad hoc queries, and no raw transaction retrieval
+      --app.profile-file string                          kwild profile output file path (e.g. cpu.pprof)
+      --app.profile-mode string                          kwild profile mode (http, cpu, mem, mutex, or block)
+      --app.rpc-max-req-size int                         RPC request size limit (default 4200000)
+      --app.rpc-timeout duration                         timeout for RPC requests (through reading the request, handling the request, and sending the response) (default 45s)
+      --app.snapshots.enabled                            Enable snapshots
+      --app.snapshots.max-snapshots uint                 Maximum snapshots to store on disk. Default is 3. If max snapshots is reached, the oldest snapshot is deleted. (default 3)
+      --app.snapshots.recurring-height uint              Recurring heights to create snapshots (default 14400)
+      --app.tls-cert-file string                         TLS certificate file path for the admin and consensus RPC server (optional)
+      --app.tls-key-file string                          TLS key file path for the admin and consensus RPC servers (optional)
+      --chain-id string                                  chain ID to use for the genesis file
+      --chain.consensus.timeout-commit duration          Chain consensus timeout commit (default 6s)
+      --chain.consensus.timeout-precommit duration       Chain consensus timeout precommit (default 2s)
+      --chain.consensus.timeout-prevote duration         Chain consensus timeout prevote (default 2s)
+      --chain.consensus.timeout-propose duration         Chain consensus timeout propose (default 3s)
+      --chain.mempool.cache-size int                     Chain mempool cache size (default 60000)
+      --chain.mempool.max-tx-bytes int                   chain mempool maximum single transaction size in bytes (default 4194304)
+      --chain.mempool.max-txs-bytes int                  chain mempool maximum total transactions in bytes (default 536870912)
+      --chain.mempool.size int                           Chain mempool size (default 50000)
+      --chain.moniker string                             Node moniker
+      --chain.p2p.addr-book-strict                       Chain P2P address book strict
+      --chain.p2p.allow-duplicate-ip                     Chain P2P allow multiple peers with the same IP address (default true)
+      --chain.p2p.dial-timeout duration                  Chain P2P dial timeout (default 3s)
+      --chain.p2p.external-address string                Chain P2P external address to advertise
+      --chain.p2p.handshake-timeout duration             Chain P2P handshake timeout (default 20s)
+      --chain.p2p.listen-addr string                     Chain P2P listen address (default "tcp://0.0.0.0:26656")
+      --chain.p2p.max-num-inbound-peers int              Chain P2P maximum number of inbound peers (default 40)
+      --chain.p2p.max-num-outbound-peers int             Chain P2P maximum number of outbound peers (default 10)
+      --chain.p2p.persistent-peers string                Chain P2P persistent peers
+      --chain.p2p.pex                                    Enables peer information exchange (default true)
+  -p, --chain.p2p.private-mode                           Run the node in private mode. In private mode, the connectivity to the node is restricted to the current validators and whitelist peers.
+      --chain.p2p.seed-mode                              Run kwild in a special "seed" mode where it crawls the network for peer addresses,
+                                                         sharing them with incoming peers before immediately disconnecting. It is recommended
+                                                         to instead run a dedicated seeder like https://github.com/kwilteam/cometseed.
+      --chain.p2p.seeds string                           Seed nodes for obtaining peer addresses, if address book is empty
+      --chain.p2p.unconditional-peer-ids string          Chain P2P unconditional peer IDs
+      --chain.p2p.whitelist-peers kwil-admin             List of allowed sentry nodes that can connect to the node. Whitelist peers can be updated dynamically using kwil-admin commands.
+      --chain.rpc.broadcast-tx-timeout duration          Chain RPC broadcast transaction timeout (default 15s)
+      --chain.rpc.listen-addr string                     Chain RPC listen address (default "tcp://127.0.0.1:26657")
+      --chain.statesync.chunk-request-timeout duration   Chain state sync chunk request timeout (default 10s)
+      --chain.statesync.discovery-time duration          Chain state sync discovery time (default 15s)
+      --chain.statesync.enable                           Chain state sync enable
+      --chain.statesync.rpc-servers string               Chain state sync rpc servers
+      --gas                                              enable gas
+  -g, --genesis string                                   path to genesis file
+  -s, --genesis-state string                             path to genesis state snapshot file
+  -h, --help                                             help for init
+      --join-expiry int                                  number of blocks before a join request expires (default 14400)
+      --log.consensus-level string                       consensus (cometbft) log level
+      --log.db-level string                              database backend (postgres) log level
+      --log.file-roll-size int                           threshold in KB at which the log file rolls over and archives the current one (default 100000)
+      --log.format string                                kwild log format (default "json")
+  -l, --log.level string                                 kwild log level (default "info")
+      --log.output-paths strings                         kwild log output paths (default [stdout,kwild.log])
+      --log.retain-max-rolls int                         retention limit on the number of archived log files to keep (default is 0, meaning retain all)
+      --log.rpc-level string                             user rpc server log level
+      --log.time-format string                           kwild time log format (default "epochfloat")
+  -r, --root-dir string                                  kwild root directory for config and data (default "~/.kwild")
 ```
 
 ### Options inherited from parent commands

--- a/docs/node/admin/kwil-admin/setup/peer.mdx
+++ b/docs/node/admin/kwil-admin/setup/peer.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: "peer"
 id: "kwil-admin-setup-peer"
 title: "kwil-admin setup peer"
@@ -32,25 +32,29 @@ kwil-admin setup peer --root-dir ./kwil-node --genesis /path/to/genesis.json --c
 ```
       --app.admin-listen-addr string                     kwild admin listen address (unix or tcp) (default "/tmp/kwild.socket")
       --app.admin-notls                                  do not enable TLS on admin server (automatically disabled for unix socket or loopback listen addresses)
-      --app.admin-pass string                            password for the kwil admin service (may be empty)
+      --app.admin-pass string                            password for the node's admin service (may be empty)
+      --app.challenge-expiry duration                    Time after which a challenge expires (default 10s)
+      --app.challenge-rate-limit float                   challenge request rate limit per second per client IP (default 10)
       --app.db-read-timeout duration                     timeout for database reads initiated by RPC requests (default 5s)
       --app.extension-endpoints strings                  kwild extension endpoints
       --app.genesis-state string                         Path to the genesis state file
       --app.hostname string                              kwild Server hostname
       --app.jsonrpc-listen-addr string                   kwild JSON-RPC listen address (default "0.0.0.0:8484")
+      --app.migrate-from string                          kwild JSON-RPC listening address of the node to replicate the state from.
       --app.pg-db-host string                            PostgreSQL host address (no port) (default "127.0.0.1")
       --app.pg-db-name string                            PostgreSQL database name (default "kwild")
       --app.pg-db-pass string                            PostgreSQL password name
       --app.pg-db-port string                            PostgreSQL port (default "5432")
       --app.pg-db-user string                            PostgreSQL user name (default "kwild")
       --app.private-key-path string                      Path to the node private key file (default "private_key")
+      --app.private-rpc                                  Enforce data privacy with authenticated call request, disabled ad hoc queries, and no raw transaction retrieval
       --app.profile-file string                          kwild profile output file path (e.g. cpu.pprof)
       --app.profile-mode string                          kwild profile mode (http, cpu, mem, mutex, or block)
+      --app.rpc-max-req-size int                         RPC request size limit (default 4200000)
       --app.rpc-timeout duration                         timeout for RPC requests (through reading the request, handling the request, and sending the response) (default 45s)
       --app.snapshots.enabled                            Enable snapshots
       --app.snapshots.max-snapshots uint                 Maximum snapshots to store on disk. Default is 3. If max snapshots is reached, the oldest snapshot is deleted. (default 3)
       --app.snapshots.recurring-height uint              Recurring heights to create snapshots (default 14400)
-      --app.snapshots.snapshot-dir string                Snapshot directory path (default "snapshots")
       --app.tls-cert-file string                         TLS certificate file path for the admin and consensus RPC server (optional)
       --app.tls-key-file string                          TLS key file path for the admin and consensus RPC servers (optional)
       --chain.consensus.timeout-commit duration          Chain consensus timeout commit (default 6s)
@@ -64,7 +68,9 @@ kwil-admin setup peer --root-dir ./kwil-node --genesis /path/to/genesis.json --c
       --chain.moniker string                             Node moniker
       --chain.p2p.addr-book-strict                       Chain P2P address book strict
       --chain.p2p.allow-duplicate-ip                     Chain P2P allow multiple peers with the same IP address (default true)
+      --chain.p2p.dial-timeout duration                  Chain P2P dial timeout (default 3s)
       --chain.p2p.external-address string                Chain P2P external address to advertise
+      --chain.p2p.handshake-timeout duration             Chain P2P handshake timeout (default 20s)
       --chain.p2p.listen-addr string                     Chain P2P listen address (default "tcp://0.0.0.0:26656")
       --chain.p2p.max-num-inbound-peers int              Chain P2P maximum number of inbound peers (default 40)
       --chain.p2p.max-num-outbound-peers int             Chain P2P maximum number of outbound peers (default 10)
@@ -76,22 +82,23 @@ kwil-admin setup peer --root-dir ./kwil-node --genesis /path/to/genesis.json --c
                                                          to instead run a dedicated seeder like https://github.com/kwilteam/cometseed.
       --chain.p2p.seeds string                           Seed nodes for obtaining peer addresses, if address book is empty
       --chain.p2p.unconditional-peer-ids string          Chain P2P unconditional peer IDs
-      --chain.p2p.whitelist-peers string                 List of allowed sentry nodes that can connect to the node. Whitelist peers can be updated dynamically using kwil-admin peer commands.
+      --chain.p2p.whitelist-peers kwil-admin             List of allowed sentry nodes that can connect to the node. Whitelist peers can be updated dynamically using kwil-admin commands.
       --chain.rpc.broadcast-tx-timeout duration          Chain RPC broadcast transaction timeout (default 15s)
       --chain.rpc.listen-addr string                     Chain RPC listen address (default "tcp://127.0.0.1:26657")
       --chain.statesync.chunk-request-timeout duration   Chain state sync chunk request timeout (default 10s)
       --chain.statesync.discovery-time duration          Chain state sync discovery time (default 15s)
       --chain.statesync.enable                           Chain state sync enable
       --chain.statesync.rpc-servers string               Chain state sync rpc servers
-      --chain.statesync.snapshot-dir string              Chain state sync snapshot directory (default "rcvdSnaps")
   -g, --genesis string                                   path to genesis file
   -h, --help                                             help for peer
-      --log.consensus_level string                       consensus (cometbft) log level
-      --log.db_level string                              database backend (postgres) log level
+      --log.consensus-level string                       consensus (cometbft) log level
+      --log.db-level string                              database backend (postgres) log level
+      --log.file-roll-size int                           threshold in KB at which the log file rolls over and archives the current one (default 100000)
       --log.format string                                kwild log format (default "json")
   -l, --log.level string                                 kwild log level (default "info")
       --log.output-paths strings                         kwild log output paths (default [stdout,kwild.log])
-      --log.rpc_level string                             user rpc server log level
+      --log.retain-max-rolls int                         retention limit on the number of archived log files to keep (default is 0, meaning retain all)
+      --log.rpc-level string                             user rpc server log level
       --log.time-format string                           kwild time log format (default "epochfloat")
   -r, --root-dir string                                  kwild root directory for config and data (default "~/.kwild")
 ```

--- a/docs/node/admin/kwil-admin/setup/reset-state.mdx
+++ b/docs/node/admin/kwil-admin/setup/reset-state.mdx
@@ -1,19 +1,23 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: "reset-state"
 id: "kwil-admin-setup-reset-state"
 title: "kwil-admin setup reset-state"
-description: "Delete blockchain state files."
+description: "`reset-state` deletes the data in Postgres."
 slug: /ref/kwil-admin/setup/reset-state
 ---
 
 ## kwil-admin setup reset-state
 
-Delete blockchain state files.
+`reset-state` deletes the data in Postgres.
 
 ### Synopsis
 
-Delete blockchain state files.
+`reset-state` deletes the data in Postgres.
+
+Unlike the `reset` command, which deletes all of the application data in Postgres and all of the block data
+in the root directory, `reset-state` only deletes the application data in Postgres. This command is useful if
+you want to replay all of the blocks without having to re-download them.
 
 ```
 kwil-admin setup reset-state [flags]
@@ -22,16 +26,18 @@ kwil-admin setup reset-state [flags]
 ### Examples
 
 ```
-# Delete blockchain state files
-kwil-admin setup reset-state --root-dir "~/.kwild"
+kwil-admin setup reset-state --host localhost --port 5432 --user kwild --password kwild --dbname kwild
 ```
 
 ### Options
 
 ```
-  -f, --force             force removal of default home directory
+      --dbname string     Name of the database in the PostgreSQL server (default "kwild")
   -h, --help              help for reset-state
-  -r, --root-dir string   root directory of the kwild node
+      --host string       Host of the database (default "localhost")
+      --password string   Password for the database user
+      --port string       Port of the database (default "5432")
+      --user string       User with administrative privileges on the database (default "postgres")
 ```
 
 ### Options inherited from parent commands

--- a/docs/node/admin/kwil-admin/setup/reset.mdx
+++ b/docs/node/admin/kwil-admin/setup/reset.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: "reset"
 id: "kwil-admin-setup-reset"
 title: "kwil-admin setup reset"
@@ -13,7 +13,7 @@ To delete all of a Kwil node's data files, use the `reset` command.
 
 ### Synopsis
 
-To delete all of a Kwil node's data files, use the `reset` command. If directories are not specified, the node's default directories will be used.
+To delete all of a Kwil node's data files, use the `reset` command. If the root directory is not specified, the node's default root directory will be used.
 
 WARNING: This command should not be used on production systems. This should only be used to reset disposable test nodes.
 
@@ -25,16 +25,20 @@ kwil-admin setup reset [flags]
 
 ```
 # Delete all of a Kwil node's data files
-kwil-admin setup reset --root-dir "~/.kwild" --sqlpath "~/.kwild/data/kwil.db"
+kwil-admin setup reset --root-dir "~/.kwild"
 ```
 
 ### Options
 
 ```
+      --dbname string     Name of the database in the PostgreSQL server (default "kwild")
   -f, --force             force removal of default home directory
   -h, --help              help for reset
+      --host string       Host of the database (default "localhost")
+      --password string   Password for the database user
+      --port string       Port of the database (default "5432")
   -r, --root-dir string   root directory of the kwild node
-  -p, --snappath string   path to the snapshot directory
+      --user string       User with administrative privileges on the database (default "postgres")
 ```
 
 ### Options inherited from parent commands

--- a/docs/node/admin/kwil-admin/setup/testnet.mdx
+++ b/docs/node/admin/kwil-admin/setup/testnet.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 sidebar_label: "testnet"
 id: "kwil-admin-setup-testnet"
 title: "kwil-admin setup testnet"
@@ -46,9 +46,6 @@ kwil-admin setup testnet -v 4 -o ./output --hostnames 192.168.10.2 192.168.10.3 
 ### Options
 
 ```
-      ----max-snaps uint          maximum number of snapshots to store in the device (default 3)
-      ----snap-heights uint       recurring heights(multipes of --snap-heights) to take snapshots at (default 10000)
-      ----snaps                   enables db snapshots
       --alloc allocFlag           account=amount pairs of genesis account allocations (default map[])
   -i, --block-interval duration   shortest block interval in seconds (default 6s)
       --chain-id string           chain ID to use for the genesis file
@@ -59,10 +56,14 @@ kwil-admin setup testnet -v 4 -o ./output --hostnames 192.168.10.2 192.168.10.3 
       --hostname-suffix string    suffix for hostnames of nodes
       --hostnames strings         override all hostnames of the nodes (list of hostnames must be the same length as the number of nodes)
       --join-expiry int           number of blocks before a join request expires (default 14400)
+      --max-snaps uint            maximum number of snapshots to store in the device (default 3)
       --node-dir-prefix string    prefix for the node directories (node results in node0, node1, ...) (default "node")
   -n, --non-validators int        number of non-validators to generate
   -o, --output-dir string         parent directory for all of generated node folders (default "./.testnet")
   -p, --p2p-port int              p2p port for nodes (default 26656)
+  -m, --private                   enable private mode for the network
+      --snap-heights uint         recurring heights (multipes of --snap-heights) to take snapshots at (default 10000)
+      --snaps                     enables db snapshots
       --starting-ip string        starting IP address for nodes (default "172.10.100.2")
   -v, --validators int            number of validators to generate (default 3)
 ```

--- a/docs/node/admin/kwil-admin/snapshot/create.mdx
+++ b/docs/node/admin/kwil-admin/snapshot/create.mdx
@@ -37,14 +37,13 @@ genesis.json    kwildb-snapshot.sql.gz
 ### Options
 
 ```
-      --dbname string      Name of the database to snapshot (default "kwild")
-  -h, --help               help for create
-      --host string        Host of the database (default "localhost")
-      --max-row-size int   Maximum row size to read from pg_dump (default: 4MB). Adjust this accordingly if you encounter 'bufio.Scanner: token too long' error. (default 4194304)
-      --password string    Password for the database user
-      --port string        Port of the database (default "5432")
-      --snapdir string     Directory to store the snapshot and hash files (default "kwild-snaps")
-      --user string        User with administrative privileges on the database (default "postgres")
+      --dbname string     Name of the database in the PostgreSQL server (default "kwild")
+  -h, --help              help for create
+      --host string       Host of the database (default "localhost")
+      --password string   Password for the database user
+      --port string       Port of the database (default "5432")
+      --snapdir string    Directory to store the snapshot and hash files (default "kwild-snaps")
+      --user string       User with administrative privileges on the database (default "postgres")
 ```
 
 ### Options inherited from parent commands

--- a/docs/node/admin/kwil-admin/snapshot/index.md
+++ b/docs/node/admin/kwil-admin/snapshot/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 99
 sidebar_label: "snapshot"
 id: "kwil-admin-snapshot"
 title: "kwil-admin snapshot"

--- a/docs/node/admin/kwil-admin/utils/index.md
+++ b/docs/node/admin/kwil-admin/utils/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 99
 sidebar_label: "utils"
 id: "kwil-admin-utils"
 title: "kwil-admin utils"

--- a/docs/node/admin/kwil-admin/validators/index.md
+++ b/docs/node/admin/kwil-admin/validators/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 99
 sidebar_label: "validators"
 id: "kwil-admin-validators"
 title: "kwil-admin validators"

--- a/docs/node/admin/kwil-admin/whitelist/add.mdx
+++ b/docs/node/admin/kwil-admin/whitelist/add.mdx
@@ -1,24 +1,24 @@
 ---
 sidebar_position: 1
 sidebar_label: "add"
-id: "kwil-admin-peers-add"
-title: "kwil-admin peers add"
-description: "Add a peer to the node's whitelist peers to accept connections from"
-slug: /ref/kwil-admin/peers/add
+id: "kwil-admin-whitelist-add"
+title: "kwil-admin whitelist add"
+description: "Add a peer to the node's whitelist of peers to accept connections from."
+slug: /ref/kwil-admin/whitelist/add
 ---
 
-## kwil-admin peers add
+## kwil-admin whitelist add
 
-Add a peer to the node's whitelist peers to accept connections from
+Add a peer to the node's whitelist of peers to accept connections from.
 
 ```
-kwil-admin peers add <peerID> [flags]
+kwil-admin whitelist add <peerID> [flags]
 ```
 
 ### Examples
 
 ```
-kwil-admin peers add <peerID>
+kwil-admin whitelist add <peerID>
 ```
 
 ### Options
@@ -41,5 +41,5 @@ kwil-admin peers add <peerID>
 
 ### SEE ALSO
 
-* [kwil-admin peers](/docs/ref/kwil-admin/peers)	 - manages the node's peers
+* [kwil-admin whitelist](/docs/ref/kwil-admin/whitelist)	 - The whitelist command is used to manage a node's peer whitelist.
 

--- a/docs/node/admin/kwil-admin/whitelist/index.md
+++ b/docs/node/admin/kwil-admin/whitelist/index.md
@@ -1,0 +1,33 @@
+---
+sidebar_position: 99
+sidebar_label: "whitelist"
+id: "kwil-admin-whitelist"
+title: "kwil-admin whitelist"
+description: "The whitelist command is used to manage a node's peer whitelist."
+slug: /ref/kwil-admin/whitelist
+---
+
+## kwil-admin whitelist
+
+The whitelist command is used to manage a node's peer whitelist.
+
+### Options
+
+```
+  -h, --help   help for whitelist
+```
+
+### Options inherited from parent commands
+
+```
+      --output string   the format for command output - either 'text' or 'json' (default "text")
+  -S, --silence         Silence logs
+```
+
+### SEE ALSO
+
+* [kwil-admin](/docs/ref/kwil-admin)	 - The Kwil node admin tool.
+* [kwil-admin whitelist add](/docs/ref/kwil-admin/whitelist/add)	 - Add a peer to the node's whitelist of peers to accept connections from.
+* [kwil-admin whitelist list](/docs/ref/kwil-admin/whitelist/list)	 - List the peers in the node's whitelist.
+* [kwil-admin whitelist remove](/docs/ref/kwil-admin/whitelist/remove)	 - Remove a peer from the node's whitelist and disconnect it.
+

--- a/docs/node/admin/kwil-admin/whitelist/list.mdx
+++ b/docs/node/admin/kwil-admin/whitelist/list.mdx
@@ -1,31 +1,31 @@
 ---
-sidebar_position: 1
-sidebar_label: "add"
-id: "kwil-admin-peers-add"
-title: "kwil-admin peers add"
-description: "Add a peer to the node's whitelist peers to accept connections from"
-slug: /ref/kwil-admin/peers/add
+sidebar_position: 2
+sidebar_label: "list"
+id: "kwil-admin-whitelist-list"
+title: "kwil-admin whitelist list"
+description: "List the peers in the node's whitelist."
+slug: /ref/kwil-admin/whitelist/list
 ---
 
-## kwil-admin peers add
+## kwil-admin whitelist list
 
-Add a peer to the node's whitelist peers to accept connections from
+List the peers in the node's whitelist.
 
 ```
-kwil-admin peers add <peerID> [flags]
+kwil-admin whitelist list [flags]
 ```
 
 ### Examples
 
 ```
-kwil-admin peers add <peerID>
+kwil-admin whitelist list
 ```
 
 ### Options
 
 ```
       --authrpc-cert string   kwild's TLS certificate, required for HTTPS server
-  -h, --help                  help for add
+  -h, --help                  help for list
       --pass string           admin server password (alternative to mTLS with tlskey/tlscert). May be set in ~/.kwil-admin/rpc-admin-pass instead.
   -s, --rpcserver string      admin RPC server address (either unix or tcp) (default "/tmp/kwild.socket")
       --tlscert string        kwil-admin's TLS certificate file for server to authenticate us (default "auth.cert")
@@ -41,5 +41,5 @@ kwil-admin peers add <peerID>
 
 ### SEE ALSO
 
-* [kwil-admin peers](/docs/ref/kwil-admin/peers)	 - manages the node's peers
+* [kwil-admin whitelist](/docs/ref/kwil-admin/whitelist)	 - The whitelist command is used to manage a node's peer whitelist.
 

--- a/docs/node/admin/kwil-admin/whitelist/remove.mdx
+++ b/docs/node/admin/kwil-admin/whitelist/remove.mdx
@@ -1,31 +1,31 @@
 ---
-sidebar_position: 1
-sidebar_label: "add"
-id: "kwil-admin-peers-add"
-title: "kwil-admin peers add"
-description: "Add a peer to the node's whitelist peers to accept connections from"
-slug: /ref/kwil-admin/peers/add
+sidebar_position: 3
+sidebar_label: "remove"
+id: "kwil-admin-whitelist-remove"
+title: "kwil-admin whitelist remove"
+description: "Remove a peer from the node's whitelist and disconnect it."
+slug: /ref/kwil-admin/whitelist/remove
 ---
 
-## kwil-admin peers add
+## kwil-admin whitelist remove
 
-Add a peer to the node's whitelist peers to accept connections from
+Remove a peer from the node's whitelist and disconnect it.
 
 ```
-kwil-admin peers add <peerID> [flags]
+kwil-admin whitelist remove <peerID> [flags]
 ```
 
 ### Examples
 
 ```
-kwil-admin peers add <peerID>
+kwil-admin whitelist remove <peerID>
 ```
 
 ### Options
 
 ```
       --authrpc-cert string   kwild's TLS certificate, required for HTTPS server
-  -h, --help                  help for add
+  -h, --help                  help for remove
       --pass string           admin server password (alternative to mTLS with tlskey/tlscert). May be set in ~/.kwil-admin/rpc-admin-pass instead.
   -s, --rpcserver string      admin RPC server address (either unix or tcp) (default "/tmp/kwild.socket")
       --tlscert string        kwil-admin's TLS certificate file for server to authenticate us (default "auth.cert")
@@ -41,5 +41,5 @@ kwil-admin peers add <peerID>
 
 ### SEE ALSO
 
-* [kwil-admin peers](/docs/ref/kwil-admin/peers)	 - manages the node's peers
+* [kwil-admin whitelist](/docs/ref/kwil-admin/whitelist)	 - The whitelist command is used to manage a node's peer whitelist.
 

--- a/docs/node/private-networks.mdx
+++ b/docs/node/private-networks.mdx
@@ -48,7 +48,7 @@ kwild -r /path/to/root/dir --chain.p2p.private-mode --chain.p2p.whitelist-peers=
 
 The current set of validators, persistent peers and seed nodes are automatically added to the whitelist. Therefore, the `whitelist_peers` field is used to restrict which non-validating read-only nodes can sync data from your node's P2P endpoint.
 
-The whitelist can also be updated dynamically using the `kwil-admin peers` commands. Refer to the [Kwil Admin Peers Subcommand](/docs/ref/kwil-admin/peers) documentation for more information.
+The whitelist can also be updated dynamically using the `kwil-admin whitelist` commands. Refer to the [Kwil Admin Peers Subcommand](/docs/ref/kwil-admin/peers) documentation for more information.
 
 :::note
 Seed nodes and persistent peers are automatically whitelisted. In order for a new node to maintain a connection with an existing node that is not a seed or persistent peer, the existing node must also add the new node to its whitelist and vice versa.
@@ -63,11 +63,11 @@ For example, to onboard a new node with the Node ID `new-node-id` to an existing
 
 1. From the **existing node**, add the new node to the whitelist as shown below:
     ```bash
-    kwil-admin peers add <new-node-id>
+    kwil-admin whitelist add <new-node-id>
     ```
 2. From the **existing node**, verify that the new node is added to its whitelist:
     ```bash
-    kwil-admin peers list
+    kwil-admin whitelist list
     ```
 3. From the **new node**, add the existing node as a seed node or persistent peer. As seeds nodes and persistent peers are automatically whitelisted, the new node should be able to connect to the existing node without explicitly adding the existing node ID to the whitelist.
 


### PR DESCRIPTION
Renamed `kwil-admin peers` to `kwil-admin whitelist`, as per the changes made here: https://github.com/kwilteam/kwil-db/pull/985

The large change here is due to the generated reference docs. There were some we were missing.