### PR TITLE
cli: remove incorrect query flag

### DIFF
--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -61,7 +61,7 @@ kwil-cli exec-action create_user text:satoshi int8:32
 To execute a SELECT statement on a database, use the `kwil-cli query` command:
 
 ```bash
-kwil-cli query --sql "SELECT * FROM users"
+kwil-cli query "SELECT * FROM users"
 ```
 
 ## Reading Data with a View Action


### PR DESCRIPTION
Removes an incorrect `--sql` flag in the `kwil-cli` docs