### PR TITLE
fix naming inconsistencies with schemas and namespaces

### DIFF
--- a/docs/language/05-namespaces.mdx
+++ b/docs/language/05-namespaces.mdx
@@ -12,7 +12,7 @@ actions, and other database objects, while avoiding naming conflicts between dif
 similar to [schemas in Postgres](<https://www.postgresql.org/docs/current/ddl-schemas.html>), and are simply given a different name
 to avoid confusion.
 
-Each database comes with two built-in schemas: `main` and `info`. If no namespace is specified, the `main` schema is used by default.
+Each database comes with two built-in namespaces: `main` and `info`. If no namespace is specified, the `main` namespace is used by default.
 `info` stores metadata about the other namespaces (such as the tables and actions they contain), and cannot be written to directly.
 
 ## Creating Namespaces
@@ -65,7 +65,7 @@ CREATE NAMESPACE my_namespace;
 
 Namespaces cannot be specified within an action body. Instead, actions can only insert, update, and delete data from tables
 within the same namespace. They _can_ read data from tables in other namespaces, but cannot write to them.
-Take, for example, the following schema:
+Take, for example, the following database schema:
 
 ```sql
 CREATE NAMESPACE my_namespace;

--- a/docs/language/07-roles.mdx
+++ b/docs/language/07-roles.mdx
@@ -8,7 +8,7 @@ slug: /language/roles
 ---
 
 Roles in Kwil allow you to define privileges that can be held by users, defining how users can interact with the database.
-Using roles, you can designate rules for how schemas can change, who can execute ad-hoc SQL statements, and set access control
+Using roles, you can designate rules for how the database schema can change, who can execute ad-hoc SQL statements, and set access control
 rules for namespaces.
 
 ## Creating Roles


### PR DESCRIPTION
Fixes a few places where I used the term "schema" when I meant "namespace"