### PR TITLE
update extension config flag name

### DIFF
--- a/docs/node/daemon/config/settings.mdx
+++ b/docs/node/daemon/config/settings.mdx
@@ -51,5 +51,5 @@ The one exception to the above is for configuring values in the `app.extensions`
 Extension configs must be specified after all others, and must be delimited from the rest of the command line arguments by a double dash `--`:
 
 ```bash
-kwild start --autogen --log.level=debug -- --extension.<extension-name>.<config-key> <config-value>
+kwild start --autogen --log.level=debug -- --extensions.<extension-name>.<config-key> <config-value>
 ```


### PR DESCRIPTION
To keep consistent, the flags for configure extension changed to `--extensions`, update the doc here